### PR TITLE
Simpify test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ cache:
         - $HOME/.composer/cache
 
 before_script:
-    - pecl install timecop-1.2.10
     - composer self-update
     - composer require --no-update symfony/config=$SYMFONY_VERSION symfony/http-kernel=$SYMFONY_VERSION symfony/dependency-injection=$SYMFONY_VERSION symfony/options-resolver=$SYMFONY_VERSION
     - composer require --no-update --dev symfony/framework-bundle=$SYMFONY_VERSION symfony/yaml=$SYMFONY_VERSION
@@ -24,4 +23,4 @@ before_script:
 script:
     - stty cols 120
     - if [ "$CHECK_CS" == 1 ]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.15.8/php-cs-fixer.phar && php php-cs-fixer.phar fix --dry-run --diff; fi
-    - PSR_HTTP_PROVIDER=nyholm vendor/bin/simple-phpunit
+    - vendor/bin/simple-phpunit

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 [![Latest Stable Version](https://poser.pugx.org/league/oauth2-server-bundle/v/stable)](https://packagist.org/packages/thephpleague/oauth2-server-bundle)
 
 OAuth2ServerBundle is a Symfony bundle integrating the [oauth2-server](https://github.com/thephpleague/oauth2-server) library into Symfony applications.
+Fork of trikoder/oauth2-bundle, for the better.
 
-## Status
+## Quick Start
 
-**Work in progress**
+1. Require the bundle and a PSR 7/17 implementation using Composer:
 
-Forked from of [Trikoder/OAuth2-Bundle](https://github.com).
+    ```sh
+    composer require league/oauth2-server-bundle nyholm/psr7
+    ```
 
 ## Documentation
 
 The docs [can be found in the `docs/` directory](docs/index.md) of this repository.
 
 ## License
-See the [LICENSE](LICENSE) file for license rights and limitations (MIT).
+See the [LICENSE](LICENSE) file for copyrights and limitations (MIT).

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "symfony/security-bundle": "^4.4|^5.0"
     },
     "require-dev": {
-        "ext-timecop": "*",
         "laminas/laminas-diactoros": "^2.2",
         "nyholm/psr7": "^1.2",
         "symfony/browser-kit": "^4.4|^5.0",

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -6,11 +6,9 @@ LABEL maintainer="Petar Obradović <petar.obradovic@trikoder.net>"
 ARG COMPOSER_VERSION=1.9.3
 ARG FLEX_VERSION=1.6.2
 ARG PHP_CS_FIXER_VERSION=2.16.2
-ARG TIMECOP_VERSION=1.2.10
 ARG XDEBUG_VERSION=2.9.2
 
 ENV XDEBUG_REMOTE_AUTOSTART 0
-ENV TIMECOP_FUNC_OVERRIDE 0
 
 # This is where we're going to store all of our non-project specific binaries
 RUN mkdir -p /app/bin
@@ -27,10 +25,8 @@ RUN apk add --update --no-cache --virtual .build-deps \
         zip \
     && pecl install \
         xdebug-${XDEBUG_VERSION} \
-        timecop-${TIMECOP_VERSION} \
     && docker-php-ext-enable \
         xdebug \
-        timecop \
     && apk del --purge .build-deps
 
 RUN mv ${PHP_INI_DIR}/php.ini-development ${PHP_INI_DIR}/php.ini
@@ -40,9 +36,6 @@ RUN echo '[xdebug]' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_enable = 1' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_connect_back = 0' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_host = %XDEBUG_REMOTE_HOST%' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini
-
-RUN echo '[timecop]' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-timecop.ini \
-    && echo 'timecop.func_override = ${TIMECOP_FUNC_OVERRIDE}' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-timecop.ini
 
 # Utilities needed to run this image
 RUN apk add --update --no-cache \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
             HOST_USER_ID: ${HOST_USER_ID}
             HOST_GROUP_ID: ${HOST_GROUP_ID}
             HOST_IP: ${HOST_IP:-}
-            PSR_HTTP_PROVIDER: ${PSR_HTTP_PROVIDER:-nyholm}
             SYMFONY_REQUIRE: ${SYMFONY_REQUIRE:-4.4.*}
         image: league/oauth2-server-bundle
         volumes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,8 @@
-# OAuth2-Server Bundle
-
-Symfony bundle which provides OAuth 2.1 authorization/resource server capabilities on top of the [thephpleague/oauth2-server](https://github.com/thephpleague/oauth2-server) library.
-
 ## Important notes
 
 This bundle provides the "glue" between  [thephpleague/oauth2-server](https://github.com/thephpleague/oauth2-server) library and the Symfony framework.
 It implements [thephpleague/oauth2-server](https://github.com/thephpleague/oauth2-server) library in a way specified by its official documentation.
 For implementation into Symfony projects, please see [bundle documentation](docs/basic-setup.md) and official [Symfony Security documentation](https://symfony.com/doc/current/security.html).
-
-## Status
-
-This package is currently in the active development.
 
 ## Features
 
@@ -124,7 +116,7 @@ This package is currently in the active development.
 
     ```yaml
     oauth2:
-        resource: '@LeagueOAuth2Bundle/Resources/config/routes.xml'
+        resource: '@LeagueOAuth2ServerBundle/Resources/config/routes.xml'
     ```
 
 You can verify that everything is working by issuing a `POST` request to the `/token` endpoint.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <env name="KERNEL_CLASS" value="League\Bundle\OAuth2ServerBundle\Tests\TestKernel" />
         <env name="SHELL_VERBOSITY" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_PHPUNIT_REMOVE" value="" />
     </php>
 
     <testsuites>
@@ -36,8 +37,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Resources/config/storage/doctrine.xml
+++ b/src/Resources/config/storage/doctrine.xml
@@ -20,34 +20,19 @@
         <service id="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\ClientManager">
             <argument key="$entityManager" />
         </service>
-        <service id="league.oauth2-server.manager.doctrine.client_manager" alias="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\ClientManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
-        </service>
 
         <service id="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\AccessTokenManager">
             <argument key="$entityManager" />
-        </service>
-        <service id="league.oauth2-server.manager.doctrine.access_token_manager" alias="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\AccessTokenManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\RefreshTokenManager">
             <argument key="$entityManager" />
         </service>
-        <service id="league.oauth2-server.manager.doctrine.refresh_token_manager" alias="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\RefreshTokenManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
-        </service>
 
         <service id="League\Bundle\OAuth2ServerBundle\Manager\InMemory\ScopeManager" />
-        <service id="league.oauth2-server.manager.in_memory.scope_manager" alias="League\Bundle\OAuth2ServerBundle\Manager\InMemory\ScopeManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
-        </service>
 
         <service id="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\AuthorizationCodeManager">
             <argument key="$entityManager" />
-        </service>
-        <service id="league.oauth2-server.manager.doctrine.authorization_code_manager" alias="League\Bundle\OAuth2ServerBundle\Manager\Doctrine\AuthorizationCodeManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
     </services>
 </container>

--- a/tests/Acceptance/AuthorizationEndpointTest.php
+++ b/tests/Acceptance/AuthorizationEndpointTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Tests\Acceptance;
 
-use DateTimeImmutable;
 use League\Bundle\OAuth2ServerBundle\Event\AuthorizationRequestResolveEvent;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AuthorizationCodeManagerInterface;
@@ -41,21 +40,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -93,24 +86,18 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => $state,
-                    'code_challenge' => $codeChallenge,
-                    'code_challenge_method' => $codeChallengeMethod,
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => $state,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -151,22 +138,16 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $this->fail('This event should not have been dispatched.');
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => bin2hex(random_bytes(20)),
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => bin2hex(random_bytes(20)),
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -195,24 +176,18 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $this->fail('This event should not have been dispatched.');
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => $state,
-                    'code_challenge' => $codeChallenge,
-                    'code_challenge_method' => $codeChallengeMethod,
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => $state,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -245,24 +220,18 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_ALLOWED_TO_USE_PLAIN_CHALLENGE_METHOD,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => $state,
-                    'code_challenge' => $codeChallenge,
-                    'code_challenge_method' => $codeChallengeMethod,
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_ALLOWED_TO_USE_PLAIN_CHALLENGE_METHOD,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => $state,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -303,21 +272,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'token',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'token',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -344,23 +307,17 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->setResponse($response);
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                    'redirect_uri' => FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI,
-                    'scope' => FixtureFactory::FIXTURE_SCOPE_FIRST . ' ' . FixtureFactory::FIXTURE_SCOPE_SECOND,
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+                'redirect_uri' => FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI,
+                'scope' => FixtureFactory::FIXTURE_SCOPE_FIRST . ' ' . FixtureFactory::FIXTURE_SCOPE_SECOND,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -382,21 +339,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
             $event->setResponse($response);
         }, 200);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -418,21 +369,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
             $event->setResponse($response);
         }, 100);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -456,22 +401,16 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                    'redirect_uri' => 'https://example.org/oauth2/malicious-uri',
-                ]
-            );
-        } finally {
-            timecop_return();
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+                'redirect_uri' => 'https://example.org/oauth2/malicious-uri',
+            ]
+        );
 
         $response = $this->client->getResponse();
 

--- a/tests/Acceptance/ClearExpiredTokensCommandTest.php
+++ b/tests/Acceptance/ClearExpiredTokensCommandTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Tests\Acceptance;
 
-use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AuthorizationCodeManagerInterface;
@@ -24,8 +23,6 @@ final class ClearExpiredTokensCommandTest extends AbstractAcceptanceTest
     {
         parent::setUp();
 
-        timecop_freeze(new DateTimeImmutable());
-
         FixtureFactory::initializeFixtures(
             $this->client->getContainer()->get(ScopeManagerInterface::class),
             $this->client->getContainer()->get(ClientManagerInterface::class),
@@ -37,8 +34,6 @@ final class ClearExpiredTokensCommandTest extends AbstractAcceptanceTest
 
     protected function tearDown(): void
     {
-        timecop_return();
-
         parent::tearDown();
     }
 

--- a/tests/Acceptance/DoctrineAccessTokenManagerTest.php
+++ b/tests/Acceptance/DoctrineAccessTokenManagerTest.php
@@ -28,20 +28,14 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        timecop_freeze(new DateTimeImmutable());
+        $testData = $this->buildClearExpiredTestData($client);
 
-        try {
-            $testData = $this->buildClearExpiredTestData($client);
-
-            /** @var AccessToken $token */
-            foreach ($testData['input'] as $token) {
-                $doctrineAccessTokenManager->save($token);
-            }
-
-            $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
-        } finally {
-            timecop_return();
+        /** @var AccessToken $token */
+        foreach ($testData['input'] as $token) {
+            $doctrineAccessTokenManager->save($token);
         }
+
+        $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
 
         $this->assertSame(
             $testData['output'],
@@ -91,23 +85,17 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        timecop_freeze(new DateTimeImmutable());
+        $testData = $this->buildClearExpiredTestDataWithRefreshToken($client);
 
-        try {
-            $testData = $this->buildClearExpiredTestDataWithRefreshToken($client);
-
-            /** @var RefreshToken $token */
-            foreach ($testData['input'] as $token) {
-                $doctrineAccessTokenManager->save($token->getAccessToken());
-                $em->persist($token);
-            }
-
-            $em->flush();
-
-            $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
-        } finally {
-            timecop_return();
+        /** @var RefreshToken $token */
+        foreach ($testData['input'] as $token) {
+            $doctrineAccessTokenManager->save($token->getAccessToken());
+            $em->persist($token);
         }
+
+        $em->flush();
+
+        $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
 
         $this->assertSame(
             $testData['output'],

--- a/tests/Acceptance/DoctrineAuthCodeManagerTest.php
+++ b/tests/Acceptance/DoctrineAuthCodeManagerTest.php
@@ -26,22 +26,16 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
         $client = new Client('client', 'secret');
         $em->persist($client);
 
-        timecop_freeze(new DateTimeImmutable());
+        $testData = $this->buildClearExpiredTestData($client);
 
-        try {
-            $testData = $this->buildClearExpiredTestData($client);
-
-            /** @var AuthorizationCode $authCode */
-            foreach ($testData['input'] as $authCode) {
-                $doctrineAuthCodeManager->save($authCode);
-            }
-
-            $em->flush();
-
-            $this->assertSame(3, $doctrineAuthCodeManager->clearExpired());
-        } finally {
-            timecop_return();
+        /** @var AuthorizationCode $authCode */
+        foreach ($testData['input'] as $authCode) {
+            $doctrineAuthCodeManager->save($authCode);
         }
+
+        $em->flush();
+
+        $this->assertSame(3, $doctrineAuthCodeManager->clearExpired());
 
         $this->assertSame(
             $testData['output'],

--- a/tests/Acceptance/DoctrineRefreshTokenManagerTest.php
+++ b/tests/Acceptance/DoctrineRefreshTokenManagerTest.php
@@ -28,23 +28,17 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        timecop_freeze(new DateTimeImmutable());
+        $testData = $this->buildClearExpiredTestData($client);
 
-        try {
-            $testData = $this->buildClearExpiredTestData($client);
-
-            /** @var RefreshToken $token */
-            foreach ($testData['input'] as $token) {
-                $em->persist($token->getAccessToken());
-                $doctrineRefreshTokenManager->save($token);
-            }
-
-            $em->flush();
-
-            $this->assertSame(3, $doctrineRefreshTokenManager->clearExpired());
-        } finally {
-            timecop_return();
+        /** @var RefreshToken $token */
+        foreach ($testData['input'] as $token) {
+            $em->persist($token->getAccessToken());
+            $doctrineRefreshTokenManager->save($token);
         }
+
+        $em->flush();
+
+        $this->assertSame(3, $doctrineRefreshTokenManager->clearExpired());
 
         $this->assertSame(
             $testData['output'],

--- a/tests/Acceptance/TokenEndpointTest.php
+++ b/tests/Acceptance/TokenEndpointTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Tests\Acceptance;
 
-use DateTimeImmutable;
 use League\Bundle\OAuth2ServerBundle\Event\UserResolveEvent;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AuthorizationCodeManagerInterface;
@@ -31,17 +30,11 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
 
     public function testSuccessfulClientCredentialsRequest(): void
     {
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'client_credentials',
-            ]);
-        } finally {
-            timecop_return();
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'client_credentials',
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -64,19 +57,13 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 $event->setUser(FixtureFactory::createUser());
             });
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'password',
-                'username' => 'user',
-                'password' => 'pass',
-            ]);
-        } finally {
-            timecop_return();
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'password',
+            'username' => 'user',
+            'password' => 'pass',
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -98,18 +85,12 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(RefreshTokenManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_REFRESH_TOKEN);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'refresh_token',
-                'refresh_token' => TestHelper::generateEncryptedPayload($refreshToken),
-            ]);
-        } finally {
-            timecop_return();
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'refresh_token',
+            'refresh_token' => TestHelper::generateEncryptedPayload($refreshToken),
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -131,19 +112,13 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(AuthorizationCodeManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_AUTH_CODE);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'authorization_code',
-                'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
-                'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
-            ]);
-        } finally {
-            timecop_return();
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
+            'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -164,18 +139,12 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(AuthorizationCodeManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_AUTH_CODE_PUBLIC_CLIENT);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                'grant_type' => 'authorization_code',
-                'redirect_uri' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_REDIRECT_URI,
-                'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
-            ]);
-        } finally {
-            timecop_return();
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_REDIRECT_URI,
+            'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
+        ]);
 
         $response = $this->client->getResponse();
 

--- a/tests/Fixtures/routes.yaml
+++ b/tests/Fixtures/routes.yaml
@@ -1,0 +1,18 @@
+oauth2:
+    resource: '@LeagueOAuth2ServerBundle/Resources/config/routes.xml'
+
+security_test:
+    path: /security-test
+    controller: League\Bundle\OAuth2ServerBundle\Tests\Fixtures\SecurityTestController::helloAction
+
+security_test_scopes:
+    path: /security-test-scopes
+    controller: League\Bundle\OAuth2ServerBundle\Tests\Fixtures\SecurityTestController::scopeAction
+    defaults:
+        oauth2_scopes: ['fancy']
+
+security_test_roles:
+    path: /security-test-roles
+    controller: League\Bundle\OAuth2ServerBundle\Tests\Fixtures\SecurityTestController::rolesAction
+    defaults:
+        oauth2_scopes: ['fancy']

--- a/tests/Integration/AuthorizationServerTest.php
+++ b/tests/Integration/AuthorizationServerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Tests\Integration;
 
-use DateTimeImmutable;
 use League\Bundle\OAuth2ServerBundle\Event\UserResolveEvent;
 use League\Bundle\OAuth2ServerBundle\Model\AccessToken;
 use League\Bundle\OAuth2ServerBundle\Model\RefreshToken;
@@ -168,14 +167,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'grant_type' => 'client_credentials',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleTokenRequest($request);
         $accessToken = $this->getAccessToken($response['access_token']);
 
         // Response assertions.
@@ -194,13 +186,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'scope' => 'fancy',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            timecop_return();
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
 
@@ -227,14 +213,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'grant_type' => 'client_credentials',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleTokenRequest($request);
         $accessToken = $this->getAccessToken($response['access_token']);
 
         // Response assertions.
@@ -261,14 +240,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'scope' => 'rock',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleTokenRequest($request);
         $accessToken = $this->getAccessToken($response['access_token']);
 
         // Response assertions.
@@ -300,14 +272,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'password' => 'pass',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleTokenRequest($request);
         $accessToken = $this->getAccessToken($response['access_token']);
         $refreshToken = $this->getRefreshToken($response['refresh_token']);
 
@@ -383,14 +348,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'refresh_token' => TestHelper::generateEncryptedPayload($existingRefreshToken),
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleTokenRequest($request);
         $accessToken = $this->getAccessToken($response['access_token']);
         $refreshToken = $this->getRefreshToken($response['refresh_token']);
 
@@ -675,14 +633,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleTokenRequest($request);
         $accessToken = $this->getAccessToken($response['access_token']);
 
         $this->assertSame('Bearer', $response['token_type']);
@@ -751,14 +702,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'client_id' => 'foo',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleAuthorizationRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleAuthorizationRequest($request);
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
         parse_str(parse_url($response->getHeaderLine('Location'), PHP_URL_FRAGMENT), $responseData);
@@ -779,13 +723,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'state' => 'quzbaz',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleAuthorizationRequest($request);
-        } finally {
-            timecop_return();
-        }
+        $response = $this->handleAuthorizationRequest($request);
 
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
@@ -808,14 +746,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
-
-        try {
-            $response = $this->handleAuthorizationRequest($request);
-        } finally {
-            timecop_return();
-        }
-
+        $response = $this->handleAuthorizationRequest($request);
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
         parse_str(parse_url($response->getHeaderLine('Location'), PHP_URL_FRAGMENT), $responseData);

--- a/tests/Unit/InMemoryAccessTokenManagerTest.php
+++ b/tests/Unit/InMemoryAccessTokenManagerTest.php
@@ -11,25 +11,22 @@ use League\Bundle\OAuth2ServerBundle\Model\Client;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
+/**
+ * @group time-sensitive
+ */
 final class InMemoryAccessTokenManagerTest extends TestCase
 {
     public function testClearExpired(): void
     {
         $inMemoryAccessTokenManager = new InMemoryAccessTokenManager();
 
-        timecop_freeze(new DateTimeImmutable());
+        $testData = $this->buildClearExpiredTestData();
 
-        try {
-            $testData = $this->buildClearExpiredTestData();
-
-            foreach ($testData['input'] as $token) {
-                $inMemoryAccessTokenManager->save($token);
-            }
-
-            $this->assertSame(3, $inMemoryAccessTokenManager->clearExpired());
-        } finally {
-            timecop_return();
+        foreach ($testData['input'] as $token) {
+            $inMemoryAccessTokenManager->save($token);
         }
+
+        $this->assertSame(3, $inMemoryAccessTokenManager->clearExpired());
 
         $reflectionProperty = new ReflectionProperty(InMemoryAccessTokenManager::class, 'accessTokens');
         $reflectionProperty->setAccessible(true);
@@ -42,8 +39,7 @@ final class InMemoryAccessTokenManagerTest extends TestCase
         $validAccessTokens = [
             '1111' => $this->buildAccessToken('1111', '+1 day'),
             '2222' => $this->buildAccessToken('2222', '+1 hour'),
-            '3333' => $this->buildAccessToken('3333', '+1 second'),
-            '4444' => $this->buildAccessToken('4444', 'now'),
+            '3333' => $this->buildAccessToken('3333', '+5 seconds'),
         ];
 
         $expiredAccessTokens = [

--- a/tests/Unit/InMemoryAuthCodeManagerTest.php
+++ b/tests/Unit/InMemoryAuthCodeManagerTest.php
@@ -17,20 +17,14 @@ final class InMemoryAuthCodeManagerTest extends TestCase
     {
         $inMemoryAuthCodeManager = new InMemoryAuthCodeManager();
 
-        timecop_freeze(new DateTimeImmutable());
+        $testData = $this->buildClearExpiredTestData();
 
-        try {
-            $testData = $this->buildClearExpiredTestData();
-
-            /** @var AuthorizationCode $authCode */
-            foreach ($testData['input'] as $authCode) {
-                $inMemoryAuthCodeManager->save($authCode);
-            }
-
-            $this->assertSame(3, $inMemoryAuthCodeManager->clearExpired());
-        } finally {
-            timecop_return();
+        /** @var AuthorizationCode $authCode */
+        foreach ($testData['input'] as $authCode) {
+            $inMemoryAuthCodeManager->save($authCode);
         }
+
+        $this->assertSame(3, $inMemoryAuthCodeManager->clearExpired());
 
         $reflectionProperty = new ReflectionProperty(InMemoryAuthCodeManager::class, 'authorizationCodes');
         $reflectionProperty->setAccessible(true);
@@ -43,8 +37,7 @@ final class InMemoryAuthCodeManagerTest extends TestCase
         $validAuthCodes = [
             '1111' => $this->buildAuthCode('1111', '+1 day'),
             '2222' => $this->buildAuthCode('2222', '+1 hour'),
-            '3333' => $this->buildAuthCode('3333', '+1 second'),
-            '4444' => $this->buildAuthCode('4444', 'now'),
+            '3333' => $this->buildAuthCode('3333', '+5 second'),
         ];
 
         $expiredAuthCodes = [

--- a/tests/Unit/InMemoryRefreshTokenManagerTest.php
+++ b/tests/Unit/InMemoryRefreshTokenManagerTest.php
@@ -18,19 +18,13 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
     {
         $inMemoryRefreshTokenManager = new InMemoryRefreshTokenManager();
 
-        timecop_freeze(new DateTimeImmutable());
+        $testData = $this->buildClearExpiredTestData();
 
-        try {
-            $testData = $this->buildClearExpiredTestData();
-
-            foreach ($testData['input'] as $token) {
-                $inMemoryRefreshTokenManager->save($token);
-            }
-
-            $this->assertSame(3, $inMemoryRefreshTokenManager->clearExpired());
-        } finally {
-            timecop_return();
+        foreach ($testData['input'] as $token) {
+            $inMemoryRefreshTokenManager->save($token);
         }
+
+        $this->assertSame(3, $inMemoryRefreshTokenManager->clearExpired());
 
         $reflectionProperty = new ReflectionProperty(InMemoryRefreshTokenManager::class, 'refreshTokens');
         $reflectionProperty->setAccessible(true);
@@ -43,8 +37,7 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
         $validRefreshTokens = [
             '1111' => $this->buildRefreshToken('1111', '+1 day'),
             '2222' => $this->buildRefreshToken('2222', '+1 hour'),
-            '3333' => $this->buildRefreshToken('3333', '+1 second'),
-            '4444' => $this->buildRefreshToken('4444', 'now'),
+            '3333' => $this->buildRefreshToken('3333', '+5 seconds'),
         ];
 
         $expiredRefreshTokens = [


### PR DESCRIPTION
- Removes the ext-timecop dev dependency
- Stop using MicroKernelTrait to avoid the need for forward compatibility layers in test classes