### PR TITLE
Drop SensioFrameworkExtraBundle dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Fork of trikoder/oauth2-bundle, for the better.
 
 ## Quick Start
 
-1. Require the bundle and a PSR 7/17 implementation using Composer:
+1. Require the bundle using Composer:
 
     ```sh
-    composer require league/oauth2-server-bundle nyholm/psr7
+    composer require league/oauth2-server-bundle
     ```
 
 ## Documentation

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.7",
         "league/oauth2-server": "^8.0",
+        "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",
-        "sensio/framework-extra-bundle": "^5.6",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/psr-http-message-bridge": "^2.0",
         "symfony/security-bundle": "^4.4|^5.0"
@@ -29,11 +29,10 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
-        "laminas/laminas-diactoros": "^2.2",
-        "nyholm/psr7": "^1.2",
         "psalm/plugin-symfony": "^2.2",
         "symfony/browser-kit": "^4.4|^5.0",
         "symfony/phpunit-bridge": "^5.2",
+        "symfony/yaml": "^4.4|^5.0",
         "vimeo/psalm": "^4.6"
     },
     "autoload": {

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -27,7 +27,6 @@ use League\OAuth2\Server\Grant\ImplicitGrant;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\ResourceServer;
-use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -117,7 +116,6 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
         $requiredBundles = [
             'doctrine' => DoctrineBundle::class,
             'security' => SecurityBundle::class,
-            'sensio_framework_extra' => SensioFrameworkExtraBundle::class,
         ];
 
         foreach ($requiredBundles as $bundleAlias => $requiredBundle) {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -57,7 +57,7 @@
         <service id="League\Bundle\OAuth2ServerBundle\Security\Firewall\OAuth2Listener">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
-            <argument type="service" id="sensio_framework_extra.psr7.http_message_factory" />
+            <argument type="service" id="league.oauth2_server.http_message_factory" />
             <argument key="$oauth2TokenFactory" type="service" id="League\Bundle\OAuth2ServerBundle\Security\Authentication\Token\OAuth2TokenFactory" />
         </service>
 
@@ -117,6 +117,9 @@
             <argument type="service" id="League\Bundle\OAuth2ServerBundle\Event\AuthorizationRequestResolveEventFactory" />
             <argument type="service" id="League\Bundle\OAuth2ServerBundle\Converter\UserConverter" />
             <argument type="service" id="League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface" />
+            <argument type="service" id="league.oauth2_server.http_message_factory" />
+            <argument type="service" id="league.oauth2_server.http_foundation_factory" />
+            <argument type="service" id="nyholm.psr7.psr17_factory" />
             <tag name="controller.service_arguments" />
         </service>
 
@@ -131,6 +134,9 @@
         <!-- Token controller -->
         <service id="League\Bundle\OAuth2ServerBundle\Controller\TokenController">
             <argument type="service" id="League\OAuth2\Server\AuthorizationServer" />
+            <argument type="service" id="league.oauth2_server.http_message_factory" />
+            <argument type="service" id="league.oauth2_server.http_foundation_factory" />
+            <argument type="service" id="nyholm.psr7.psr17_factory" />
             <tag name="controller.service_arguments" />
         </service>
 
@@ -177,5 +183,17 @@
         <service id="League\Bundle\OAuth2ServerBundle\Security\Authentication\Token\OAuth2TokenFactory">
             <argument type="string" />
         </service>
+
+        <!-- PSR-7/17 -->
+        <service id="nyholm.psr7.psr17_factory" class="Nyholm\Psr7\Factory\Psr17Factory" />
+
+        <service id="league.oauth2_server.http_message_factory" class="Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory">
+            <argument type="service" id="nyholm.psr7.psr17_factory" />
+            <argument type="service" id="nyholm.psr7.psr17_factory" />
+            <argument type="service" id="nyholm.psr7.psr17_factory" />
+            <argument type="service" id="nyholm.psr7.psr17_factory" />
+        </service>
+
+        <service id="league.oauth2_server.http_foundation_factory" class="Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory" />
     </services>
 </container>


### PR DESCRIPTION
- Drop SensioFrameworkExtraBundle dependency
- Don't abstract anymore the PSR7/17 implementation and require `nyholm/psr7` implementation. Therefore drop `laminas/laminas-diactoros` implementation in tests
- Fix test kernel location (`Tests -> tests`)