### PR TITLE
Add "bundle friendly" aliases

### DIFF
--- a/docs/controlling-token-scopes.md
+++ b/docs/controlling-token-scopes.md
@@ -1,6 +1,6 @@
 # Controlling token scopes
 
-It's possible to alter issued access token's scopes by subscribing to the `league.oauth2-server.scope_resolve` event.
+It's possible to alter issued access token's scopes by subscribing to the `league.oauth2_server.scope_resolve` event.
 
 ## Example
 
@@ -30,5 +30,5 @@ final class ScopeResolveListener
 ```yaml
 App\EventListener\ScopeResolveListener:
     tags:
-        - { name: kernel.event_listener, event: league.oauth2-server.scope_resolve, method: onScopeResolve }
+        - { name: kernel.event_listener, event: league.oauth2_server.scope_resolve, method: onScopeResolve }
 ```

--- a/docs/implementing-custom-grant-type.md
+++ b/docs/implementing-custom-grant-type.md
@@ -48,7 +48,7 @@
     ```
 
 1. In order to enable the new grant type in the authorization server you must register the service in the container.
-The service must be autoconfigured or you have to manually tag it with the `league.oauth2-server.authorization_server.grant` tag:
+The service must be autoconfigured or you have to manually tag it with the `league.oauth2_server.authorization_server.grant` tag:
 
     ```yaml
     services:

--- a/psalm.xml
+++ b/psalm.xml
@@ -59,6 +59,12 @@
                 <file name="src/Resources/config/services.php" />
             </errorLevel>
         </MixedReturnStatement>
+        <InvalidArgument errorLevel="error">
+            <errorLevel type="suppress">
+                <file name="src/Resources/config/routes.php" />
+                <referencedFunction name="Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator::controller" />
+            </errorLevel>
+        </InvalidArgument>
     </issueHandlers>
 
     <plugins>

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -60,10 +60,10 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
         $this->configureResourceServer($container, $config['resource_server']);
         $this->configureScopes($container, $config['scopes']);
 
-        $container->getDefinition(OAuth2TokenFactory::class)
+        $container->findDefinition(OAuth2TokenFactory::class)
             ->setArgument(0, $config['role_prefix']);
 
-        $container->getDefinition(ConvertExceptionToResponseListener::class)
+        $container->findDefinition(ConvertExceptionToResponseListener::class)
             ->addTag('kernel.event_listener', [
                 'event' => KernelEvents::EXCEPTION,
                 'method' => 'onKernelException',
@@ -71,7 +71,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
             ]);
 
         $container->registerForAutoconfiguration(GrantTypeInterface::class)
-            ->addTag('league.oauth2-server.authorization_server.grant');
+            ->addTag('league.oauth2_server.authorization_server.grant');
     }
 
     /**
@@ -128,7 +128,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
     private function configureAuthorizationServer(ContainerBuilder $container, array $config): void
     {
         $authorizationServer = $container
-            ->getDefinition(AuthorizationServer::class)
+            ->findDefinition(AuthorizationServer::class)
             ->replaceArgument(3, new Definition(CryptKey::class, [
                 $config['private_key'],
                 $config['private_key_passphrase'],
@@ -145,9 +145,9 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
             $keyDefinition = (new Definition(Key::class))
                 ->setFactory([Key::class, 'loadFromAsciiSafeString'])
                 ->addArgument($config['encryption_key']);
-            $container->setDefinition('league.oauth2-server.defuse_key', $keyDefinition);
+            $container->setDefinition('league.oauth2_server.defuse_key', $keyDefinition);
 
-            $authorizationServer->replaceArgument(4, new Reference('league.oauth2-server.defuse_key'));
+            $authorizationServer->replaceArgument(4, new Reference('league.oauth2_server.defuse_key'));
         }
 
         if ($config['enable_client_credentials_grant']) {
@@ -191,20 +191,20 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
     private function configureGrants(ContainerBuilder $container, array $config): void
     {
         $container
-            ->getDefinition(PasswordGrant::class)
+            ->findDefinition(PasswordGrant::class)
             ->addMethodCall('setRefreshTokenTTL', [
                 new Definition(\DateInterval::class, [$config['refresh_token_ttl']]),
             ])
         ;
 
         $container
-            ->getDefinition(RefreshTokenGrant::class)
+            ->findDefinition(RefreshTokenGrant::class)
             ->addMethodCall('setRefreshTokenTTL', [
                 new Definition(\DateInterval::class, [$config['refresh_token_ttl']]),
             ])
         ;
 
-        $authCodeGrantDefinition = $container->getDefinition(AuthCodeGrant::class);
+        $authCodeGrantDefinition = $container->findDefinition(AuthCodeGrant::class);
         $authCodeGrantDefinition->replaceArgument(2, new Definition(\DateInterval::class, [$config['auth_code_ttl']]))
             ->addMethodCall('setRefreshTokenTTL', [
                 new Definition(\DateInterval::class, [$config['refresh_token_ttl']]),
@@ -216,7 +216,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
         }
 
         $container
-            ->getDefinition(ImplicitGrant::class)
+            ->findDefinition(ImplicitGrant::class)
             ->replaceArgument(0, new Definition(\DateInterval::class, [$config['access_token_ttl']]))
         ;
     }
@@ -254,43 +254,43 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
         );
 
         $container
-            ->getDefinition(AccessTokenManager::class)
+            ->findDefinition(AccessTokenManager::class)
             ->replaceArgument(0, $entityManager)
         ;
 
         $container
-            ->getDefinition(ClientManager::class)
+            ->findDefinition(ClientManager::class)
             ->replaceArgument(0, $entityManager)
         ;
 
         $container
-            ->getDefinition(RefreshTokenManager::class)
+            ->findDefinition(RefreshTokenManager::class)
             ->replaceArgument(0, $entityManager)
         ;
 
         $container
-            ->getDefinition(AuthorizationCodeManager::class)
+            ->findDefinition(AuthorizationCodeManager::class)
             ->replaceArgument(0, $entityManager)
         ;
 
         $container
-            ->getDefinition(DoctrineCredentialsRevoker::class)
+            ->findDefinition(DoctrineCredentialsRevoker::class)
             ->replaceArgument(0, $entityManager)
         ;
 
-        $container->setParameter('league.oauth2-server.persistence.doctrine.enabled', true);
-        $container->setParameter('league.oauth2-server.persistence.doctrine.manager', $entityManagerName);
+        $container->setParameter('league.oauth2_server.persistence.doctrine.enabled', true);
+        $container->setParameter('league.oauth2_server.persistence.doctrine.manager', $entityManagerName);
     }
 
     private function configureInMemoryPersistence(ContainerBuilder $container): void
     {
-        $container->setParameter('league.oauth2-server.persistence.in_memory.enabled', true);
+        $container->setParameter('league.oauth2_server.persistence.in_memory.enabled', true);
     }
 
     private function configureResourceServer(ContainerBuilder $container, array $config): void
     {
         $container
-            ->getDefinition(ResourceServer::class)
+            ->findDefinition(ResourceServer::class)
             ->replaceArgument(1, new Definition(CryptKey::class, [
                 $config['public_key'],
                 null,
@@ -302,7 +302,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
     private function configureScopes(ContainerBuilder $container, array $scopes): void
     {
         $scopeManager = $container
-            ->getDefinition(
+            ->findDefinition(
                 (string) $container->getAlias(ScopeManagerInterface::class)
             )
         ;

--- a/src/LeagueOAuth2ServerBundle.php
+++ b/src/LeagueOAuth2ServerBundle.php
@@ -52,9 +52,9 @@ final class LeagueOAuth2ServerBundle extends Bundle
                     $modelDirectory => 'League\Bundle\OAuth2ServerBundle\Model',
                 ],
                 [
-                    'league.oauth2-server.persistence.doctrine.manager',
+                    'league.oauth2_server.persistence.doctrine.manager',
                 ],
-                'league.oauth2-server.persistence.doctrine.enabled',
+                'league.oauth2_server.persistence.doctrine.enabled',
                 [
                     'LeagueOAuth2ServerBundle' => 'League\Bundle\OAuth2ServerBundle\Model',
                 ]

--- a/src/OAuth2Events.php
+++ b/src/OAuth2Events.php
@@ -12,7 +12,7 @@ final class OAuth2Events
      *
      * You should set a valid user here if applicable.
      */
-    public const USER_RESOLVE = 'league.oauth2-server.user_resolve';
+    public const USER_RESOLVE = 'league.oauth2_server.user_resolve';
 
     /**
      * The SCOPE_RESOLVE event occurs right before the user obtains their
@@ -20,7 +20,7 @@ final class OAuth2Events
      *
      * You could alter the access token's scope here.
      */
-    public const SCOPE_RESOLVE = 'league.oauth2-server.scope_resolve';
+    public const SCOPE_RESOLVE = 'league.oauth2_server.scope_resolve';
 
     /**
      * The AUTHORIZATION_REQUEST_RESOLVE event occurs right before the system
@@ -29,5 +29,5 @@ final class OAuth2Events
      * You could approve or deny the authorization request, or set the uri where
      * must be redirected to resolve the authorization request.
      */
-    public const AUTHORIZATION_REQUEST_RESOLVE = 'league.oauth2-server.authorization_request_resolve';
+    public const AUTHORIZATION_REQUEST_RESOLVE = 'league.oauth2_server.authorization_request_resolve';
 }

--- a/src/Resources/config/routes.php
+++ b/src/Resources/config/routes.php
@@ -2,17 +2,15 @@
 
 declare(strict_types=1);
 
-use League\Bundle\OAuth2ServerBundle\Controller\AuthorizationController;
-use League\Bundle\OAuth2ServerBundle\Controller\TokenController;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return function (RoutingConfigurator $routes) {
     $routes
         ->add('oauth2_authorize', '/authorize')
-        ->controller([AuthorizationController::class, 'indexAction'])
+        ->controller(['league.oauth2_server.controller.authorization', 'indexAction'])
 
         ->add('oauth2_token', '/token')
-        ->controller([TokenController::class, 'indexAction'])
+        ->controller(['league.oauth2_server.controller.token', 'indexAction'])
         ->methods(['POST'])
     ;
 };

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -74,79 +74,89 @@ return static function (ContainerConfigurator $container): void {
     $container->services()
 
         // League repositories
-        ->set(ClientRepository::class)
+        ->set('league.oauth2_server.repository.client', ClientRepository::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
-        ->alias(ClientRepositoryInterface::class, ClientRepository::class)
+        ->alias(ClientRepositoryInterface::class, 'league.oauth2_server.repository.client')
+        ->alias(ClientRepository::class, 'league.oauth2_server.repository.client')
 
-        ->set(AccessTokenRepository::class)
+        ->set('league.oauth2_server.repository.access_token', AccessTokenRepository::class)
             ->args([
                 service(AccessTokenManagerInterface::class),
                 service(ClientManagerInterface::class),
-                service(ScopeConverter::class),
+                service(ScopeConverterInterface::class),
             ])
-        ->alias(AccessTokenRepositoryInterface::class, AccessTokenRepository::class)
+        ->alias(AccessTokenRepositoryInterface::class, 'league.oauth2_server.repository.access_token')
+        ->alias(AccessTokenRepository::class, 'league.oauth2_server.repository.access_token')
 
-        ->set(RefreshTokenRepository::class)
+        ->set('league.oauth2_server.repository.refresh_token', RefreshTokenRepository::class)
             ->args([
                 service(RefreshTokenManagerInterface::class),
                 service(AccessTokenManagerInterface::class),
             ])
-        ->alias(RefreshTokenRepositoryInterface::class, RefreshTokenRepository::class)
+        ->alias(RefreshTokenRepositoryInterface::class, 'league.oauth2_server.repository.refresh_token')
+        ->alias(RefreshTokenRepository::class, 'league.oauth2_server.repository.refresh_token')
 
-        ->set(ScopeRepository::class)
+        ->set('league.oauth2_server.repository.scope', ScopeRepository::class)
             ->args([
                 service(ScopeManagerInterface::class),
                 service(ClientManagerInterface::class),
-                service(ScopeConverter::class),
+                service(ScopeConverterInterface::class),
                 service(EventDispatcherInterface::class),
             ])
-        ->alias(ScopeRepositoryInterface::class, ScopeRepository::class)
+        ->alias(ScopeRepositoryInterface::class, 'league.oauth2_server.repository.scope')
+        ->alias(ScopeRepository::class, 'league.oauth2_server.repository.scope')
 
-        ->set(UserRepository::class)
+        ->set('league.oauth2_server.repository.user', UserRepository::class)
             ->args([
                 service(ClientManagerInterface::class),
                 service(EventDispatcherInterface::class),
-                service(UserConverter::class),
+                service(UserConverterInterface::class),
             ])
-        ->alias(UserRepositoryInterface::class, UserRepository::class)
+        ->alias(UserRepositoryInterface::class, 'league.oauth2_server.repository.user')
+        ->alias(UserRepository::class, 'league.oauth2_server.repository.user')
 
-        ->set(AuthCodeRepository::class)
+        ->set('league.oauth2_server.repository.auth_code', AuthCodeRepository::class)
             ->args([
                 service(AuthorizationCodeManagerInterface::class),
                 service(ClientManagerInterface::class),
-                service(ScopeConverter::class),
+                service(ScopeConverterInterface::class),
             ])
-        ->alias(AuthCodeRepositoryInterface::class, AuthCodeRepository::class)
+        ->alias(AuthCodeRepositoryInterface::class, 'league.oauth2_server.repository.auth_code')
+        ->alias(AuthCodeRepository::class, 'league.oauth2_server.repository.auth_code')
 
         // Security layer
-        ->set(OAuth2Provider::class)
+        ->set('league.oauth2_server.provider.oauth2', OAuth2Provider::class)
             ->args([
                 service(UserProviderInterface::class),
                 service(ResourceServer::class),
                 service(OAuth2TokenFactory::class),
                 null,
             ])
+        ->alias(OAuth2Provider::class, 'league.oauth2_server.provider.oauth2')
 
-        ->set(OAuth2EntryPoint::class)
+        ->set('league.oauth2_server.security.entrypoint.oauth2', OAuth2EntryPoint::class)
+        ->alias(OAuth2EntryPoint::class, 'league.oauth2_server.security.entrypoint.oauth2')
 
-        ->set(OAuth2Listener::class)
+        ->set('league.oauth2_server.security.firewall.oauth2_listener', OAuth2Listener::class)
             ->args([
                 service(TokenStorageInterface::class),
                 service(AuthenticationManagerInterface::class),
-                service('league.oauth2-server.psr_http_factory'),
+                service('league.oauth2_server.factory.psr_http'),
                 service(OAuth2TokenFactory::class),
                 null,
             ])
+        ->alias(OAuth2Listener::class, 'league.oauth2_server.security.firewall.oauth2_listener')
 
-        ->set(GrantConfigurator::class)
+        ->set('league.oauth2_server.authorization_server.grant_configurator', GrantConfigurator::class)
             ->args([
-                tagged_iterator('league.oauth2-server.authorization_server.grant'),
+                tagged_iterator('league.oauth2_server.authorization_server.grant'),
             ])
+        ->alias(GrantConfigurator::class, 'league.oauth2_server.authorization_server.grant_configurator')
 
         // League authorization server
-        ->set(AuthorizationServer::class)
+        ->set('league.oauth2_server.authorization_server', AuthorizationServer::class)
             ->args([
                 service(ClientRepositoryInterface::class),
                 service(AccessTokenRepositoryInterface::class),
@@ -155,150 +165,164 @@ return static function (ContainerConfigurator $container): void {
                 null,
             ])
             ->configurator(service(GrantConfigurator::class))
-        ->alias('league.oauth2-server.authorization_server', AuthorizationServer::class)
+        ->alias(AuthorizationServer::class, 'league.oauth2_server.authorization_server')
 
         // League resource server
-        ->set(ResourceServer::class)
+        ->set('league.oauth2_server.resource_server', ResourceServer::class)
             ->args([
                 service(AccessTokenRepositoryInterface::class),
                 null,
             ])
-        ->alias('league.oauth2-server.resource_server', ResourceServer::class)
+        ->alias(ResourceServer::class, 'league.oauth2_server.resource_server')
 
         // League authorization server grants
-        ->set(ClientCredentialsGrant::class)
-        ->alias('league.oauth2-server.client_credentials_grant', ClientCredentialsGrant::class)
+        ->set('league.oauth2_server.grant.client_credentials', ClientCredentialsGrant::class)
+        ->alias(ClientCredentialsGrant::class, 'league.oauth2_server.grant.client_credentials')
 
-        ->set(PasswordGrant::class)
+        ->set('league.oauth2_server.grant.password', PasswordGrant::class)
             ->args([
                 service(UserRepositoryInterface::class),
                 service(RefreshTokenRepositoryInterface::class),
             ])
-        ->alias('league.oauth2-server.password_grant', PasswordGrant::class)
+        ->alias(PasswordGrant::class, 'league.oauth2_server.grant.password')
 
-        ->set(RefreshTokenGrant::class)
+        ->set('league.oauth2_server.grant.refresh_token', RefreshTokenGrant::class)
             ->args([
                 service(RefreshTokenRepositoryInterface::class),
             ])
-        ->alias('league.oauth2-server.refresh_token_grant', RefreshTokenGrant::class)
+        ->alias(RefreshTokenGrant::class, 'league.oauth2_server.grant.refresh_token')
 
-        ->set(AuthCodeGrant::class)
+        ->set('league.oauth2_server.grant.auth_code', AuthCodeGrant::class)
             ->args([
                 service(AuthCodeRepositoryInterface::class),
                 service(RefreshTokenRepositoryInterface::class),
                 null,
             ])
-        ->alias('league.oauth2-server.auth_code_grant', AuthCodeGrant::class)
+        ->alias(AuthCodeGrant::class, 'league.oauth2_server.grant.auth_code')
 
-        ->set(ImplicitGrant::class)
+        ->set('league.oauth2_server.grant.implicit', ImplicitGrant::class)
             ->args([
                 null,
             ])
-        ->alias('league.oauth2-server.implicit_grant', ImplicitGrant::class)
+        ->alias(ImplicitGrant::class, 'league.oauth2_server.grant.implicit')
 
         // Authorization controller
-        ->set(AuthorizationController::class)
+        ->set('league.oauth2_server.controller.authorization', AuthorizationController::class)
             ->args([
                 service(AuthorizationServer::class),
                 service(EventDispatcherInterface::class),
                 service(AuthorizationRequestResolveEventFactory::class),
-                service(UserConverter::class),
+                service(UserConverterInterface::class),
                 service(ClientManagerInterface::class),
-                service('league.oauth2-server.psr_http_factory'),
-                service('league.oauth2-server.http_foundation_factory'),
-                service(Psr17Factory::class),
+                service('league.oauth2_server.factory.psr_http'),
+                service('league.oauth2_server.factory.http_foundation'),
+                service('league.oauth2_server.factory.psr17'),
             ])
             ->tag('controller.service_arguments')
+        ->alias(AuthorizationController::class, 'league.oauth2_server.controller.authorization')
 
         // Authorization listeners
-        ->set(AuthorizationRequestUserResolvingListener::class)
+        ->set('league.oauth2_server.listener.authorization_request_user_resolving', AuthorizationRequestUserResolvingListener::class)
             ->args([
                 service(Security::class),
             ])
             ->tag('kernel.event_listener', [
-                'event' => 'league.oauth2-server.authorization_request_resolve',
+                'event' => 'league.oauth2_server.authorization_request_resolve',
                 'method' => 'onAuthorizationRequest',
                 'priority' => 1024,
             ])
+        ->alias(AuthorizationRequestUserResolvingListener::class, 'league.oauth2_server.listener.authorization_request_user_resolving')
 
-        ->set(ConvertExceptionToResponseListener::class)
+        ->set('league.oauth2_server.listener.convert_exception_to_response', ConvertExceptionToResponseListener::class)
+        ->alias(ConvertExceptionToResponseListener::class, 'league.oauth2_server.listener.convert_exception_to_response')
 
         // Token controller
-        ->set(TokenController::class)
+        ->set('league.oauth2_server.controller.token', TokenController::class)
             ->args([
                 service(AuthorizationServer::class),
-                service('league.oauth2-server.psr_http_factory'),
-                service('league.oauth2-server.http_foundation_factory'),
-                service(Psr17Factory::class),
+                service('league.oauth2_server.factory.psr_http'),
+                service('league.oauth2_server.factory.http_foundation'),
+                service('league.oauth2_server.factory.psr17'),
             ])
             ->tag('controller.service_arguments')
+        ->alias(TokenController::class, 'league.oauth2_server.controller.token')
 
         // Commands
-        ->set(CreateClientCommand::class)
+        ->set('league.oauth2_server.command.create_client', CreateClientCommand::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
             ->tag('console.command')
+        ->alias(CreateClientCommand::class, 'league.oauth2_server.command.create_client')
 
-        ->set(UpdateClientCommand::class)
+        ->set('league.oauth2_server.command.update_client', UpdateClientCommand::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
             ->tag('console.command')
+        ->alias(UpdateClientCommand::class, 'league.oauth2_server.command.update_client')
 
-        ->set(DeleteClientCommand::class)
+        ->set('league.oauth2_server.command.delete_client', DeleteClientCommand::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
             ->tag('console.command')
+        ->alias(DeleteClientCommand::class, 'league.oauth2_server.command.delete_client')
 
-        ->set(ListClientsCommand::class)
+        ->set('league.oauth2_server.command.list_clients', ListClientsCommand::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
             ->tag('console.command')
+        ->alias(ListClientsCommand::class, 'league.oauth2_server.command.list_clients')
 
-        ->set(ClearExpiredTokensCommand::class)
+        ->set('league.oauth2_server.command.clear_expired_tokens', ClearExpiredTokensCommand::class)
             ->args([
                 service(AccessTokenManagerInterface::class),
                 service(RefreshTokenManagerInterface::class),
                 service(AuthorizationCodeManagerInterface::class),
             ])
             ->tag('console.command')
+        ->alias(ClearExpiredTokensCommand::class, 'league.oauth2_server.command.clear_expired_tokens')
 
         // Utility services
-        ->set(UserConverter::class)
-        ->alias(UserConverterInterface::class, UserConverter::class)
+        ->set('league.oauth2_server.converter.user', UserConverter::class)
+        ->alias(UserConverterInterface::class, 'league.oauth2_server.converter.user')
+        ->alias(UserConverter::class, 'league.oauth2_server.converter.user')
 
-        ->set(ScopeConverter::class)
-        ->alias(ScopeConverterInterface::class, ScopeConverter::class)
+        ->set('league.oauth2_server.converter.scope', ScopeConverter::class)
+        ->alias(ScopeConverterInterface::class, 'league.oauth2_server.converter.scope')
+        ->alias(ScopeConverter::class, 'league.oauth2_server.converter.scope')
 
-        ->set(AuthorizationRequestResolveEventFactory::class)
+        ->set('league.oauth2_server.factory.authorization_request_resolve_event', AuthorizationRequestResolveEventFactory::class)
             ->args([
-                service(ScopeConverter::class),
+                service(ScopeConverterInterface::class),
                 service(ClientManagerInterface::class),
             ])
+        ->alias(AuthorizationRequestResolveEventFactory::class, 'league.oauth2_server.factory.authorization_request_resolve_event')
 
-        ->set(OAuth2TokenFactory::class)
+        ->set('league.oauth2_server.factory.oauth2_token', OAuth2TokenFactory::class)
+        ->alias(OAuth2TokenFactory::class, 'league.oauth2_server.factory.oauth2_token')
 
         // Storage managers
-        ->set(ScopeManager::class)
+        ->set('league.oauth2_server.manager.in_memory.scope', ScopeManager::class)
             ->args([
                 null,
             ])
-        ->alias(ScopeManagerInterface::class, ScopeManager::class)
+        ->alias(ScopeManagerInterface::class, 'league.oauth2_server.manager.in_memory.scope')
+        ->alias(ScopeManager::class, 'league.oauth2_server.manager.in_memory.scope')
 
         // PSR-7/17
-        ->set(Psr17Factory::class)
+        ->set('league.oauth2_server.factory.psr17', Psr17Factory::class)
 
-        ->set('league.oauth2-server.psr_http_factory', PsrHttpFactory::class)
+        ->set('league.oauth2_server.factory.psr_http', PsrHttpFactory::class)
             ->args([
-                service(Psr17Factory::class),
-                service(Psr17Factory::class),
-                service(Psr17Factory::class),
-                service(Psr17Factory::class),
+                service('league.oauth2_server.factory.psr17'),
+                service('league.oauth2_server.factory.psr17'),
+                service('league.oauth2_server.factory.psr17'),
+                service('league.oauth2_server.factory.psr17'),
             ])
 
-        ->set('league.oauth2-server.http_foundation_factory', HttpFoundationFactory::class)
+        ->set('league.oauth2_server.factory.http_foundation', HttpFoundationFactory::class)
     ;
 };

--- a/src/Resources/config/storage/doctrine.php
+++ b/src/Resources/config/storage/doctrine.php
@@ -22,29 +22,34 @@ return static function (ContainerConfigurator $container): void {
                 null,
             ])
         ->alias(ClientManagerInterface::class, ClientManager::class)
+        ->alias('league.oauth2_server.manager.doctrine.client', ClientManager::class)
 
         ->set(AccessTokenManager::class)
             ->args([
                 null,
             ])
         ->alias(AccessTokenManagerInterface::class, AccessTokenManager::class)
+        ->alias('league.oauth2_server.manager.doctrine.access_token', AccessTokenManager::class)
 
         ->set(RefreshTokenManager::class)
             ->args([
                 null,
             ])
         ->alias(RefreshTokenManagerInterface::class, RefreshTokenManager::class)
+        ->alias('league.oauth2_server.manager.doctrine.refresh_token', RefreshTokenManager::class)
 
         ->set(AuthorizationCodeManager::class)
             ->args([
                 null,
             ])
         ->alias(AuthorizationCodeManagerInterface::class, AuthorizationCodeManager::class)
+        ->alias('league.oauth2_server.manager.doctrine.authorization_code', AuthorizationCodeManager::class)
 
         ->set(DoctrineCredentialsRevoker::class)
             ->args([
                 null,
             ])
         ->alias(CredentialsRevokerInterface::class, DoctrineCredentialsRevoker::class)
+        ->alias('league.oauth2_server.credentials_revoker.doctrine', DoctrineCredentialsRevoker::class)
     ;
 };

--- a/src/Resources/config/storage/in_memory.php
+++ b/src/Resources/config/storage/in_memory.php
@@ -20,23 +20,27 @@ return static function (ContainerConfigurator $container): void {
                 null,
             ])
         ->alias(ClientManagerInterface::class, ClientManager::class)
+        ->alias('league.oauth2_server.manager.in_memory.client', ClientManager::class)
 
         ->set(AccessTokenManager::class)
             ->args([
                 null,
             ])
         ->alias(AccessTokenManagerInterface::class, AccessTokenManager::class)
+        ->alias('league.oauth2_server.manager.in_memory.access_token', AccessTokenManager::class)
 
         ->set(RefreshTokenManager::class)
             ->args([
                 null,
             ])
         ->alias(RefreshTokenManagerInterface::class, RefreshTokenManager::class)
+        ->alias('league.oauth2_server.manager.in_memory.refresh_token', RefreshTokenManager::class)
 
         ->set(AuthorizationCodeManager::class)
             ->args([
                 null,
             ])
         ->alias(AuthorizationCodeManagerInterface::class, AuthorizationCodeManager::class)
+        ->alias('league.oauth2_server.manager.in_memory.authorization_code', AuthorizationCodeManager::class)
     ;
 };

--- a/tests/Acceptance/TokenEndpointTest.php
+++ b/tests/Acceptance/TokenEndpointTest.php
@@ -54,7 +54,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $this->client
             ->getContainer()
             ->get('event_dispatcher')
-            ->addListener('league.oauth2-server.user_resolve', static function (UserResolveEvent $event): void {
+            ->addListener('league.oauth2_server.user_resolve', static function (UserResolveEvent $event): void {
                 $event->setUser(FixtureFactory::createUser());
             });
 

--- a/tests/Integration/AuthorizationServerTest.php
+++ b/tests/Integration/AuthorizationServerTest.php
@@ -265,7 +265,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
     public function testValidPasswordGrant(): void
     {
-        $this->eventDispatcher->addListener('league.oauth2-server.user_resolve', static function (UserResolveEvent $event): void {
+        $this->eventDispatcher->addListener('league.oauth2_server.user_resolve', static function (UserResolveEvent $event): void {
             $event->setUser(FixtureFactory::createUser());
         });
 
@@ -294,7 +294,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
     public function testInvalidCredentialsPasswordGrant(): void
     {
-        $this->eventDispatcher->addListener('league.oauth2-server.user_resolve', static function (UserResolveEvent $event): void {
+        $this->eventDispatcher->addListener('league.oauth2_server.user_resolve', static function (UserResolveEvent $event): void {
             $event->setUser(null);
         });
 

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -152,47 +152,27 @@ final class TestKernel extends Kernel implements CompilerPassInterface
     private function exposeManagerServices(ContainerBuilder $container): void
     {
         $container
-            ->getDefinition(
-                (string) $container
-                    ->getAlias(ScopeManagerInterface::class)
-                    ->setPublic(true)
-            )
+            ->getAlias(ScopeManagerInterface::class)
             ->setPublic(true)
         ;
 
         $container
-            ->getDefinition(
-                (string) $container
-                    ->getAlias(ClientManagerInterface::class)
-                    ->setPublic(true)
-            )
+            ->getAlias(ClientManagerInterface::class)
             ->setPublic(true)
         ;
 
         $container
-            ->getDefinition(
-                (string) $container
-                    ->getAlias(AccessTokenManagerInterface::class)
-                    ->setPublic(true)
-            )
+            ->getAlias(AccessTokenManagerInterface::class)
             ->setPublic(true)
         ;
 
         $container
-            ->getDefinition(
-                (string) $container
-                    ->getAlias(RefreshTokenManagerInterface::class)
-                    ->setPublic(true)
-            )
+            ->getAlias(RefreshTokenManagerInterface::class)
             ->setPublic(true)
         ;
 
         $container
-            ->getDefinition(
-                (string) $container
-                    ->getAlias(AuthorizationCodeManagerInterface::class)
-                    ->setPublic(true)
-            )
+            ->getAlias(AuthorizationCodeManagerInterface::class)
             ->setPublic(true)
         ;
     }

--- a/tests/Unit/ExtensionTest.php
+++ b/tests/Unit/ExtensionTest.php
@@ -29,7 +29,7 @@ final class ExtensionTest extends TestCase
 
         $extension->load($this->getValidConfiguration([$grantKey => $shouldTheGrantBeEnabled]), $container);
 
-        $authorizationServer = $container->getDefinition(AuthorizationServer::class);
+        $authorizationServer = $container->findDefinition(AuthorizationServer::class);
         $methodCalls = $authorizationServer->getMethodCalls();
         $isGrantEnabled = false;
 
@@ -83,7 +83,7 @@ final class ExtensionTest extends TestCase
 
         $extension->load($configuration, $container);
 
-        $authorizationServer = $container->getDefinition(AuthCodeGrant::class);
+        $authorizationServer = $container->findDefinition(AuthCodeGrant::class);
         $methodCalls = $authorizationServer->getMethodCalls();
 
         $isRequireCodeChallengeForPublicClientsDisabled = false;


### PR DESCRIPTION
- Added bundle friendly aliases for services
- Changed alias namespace from `league.oauth2-server` to `league.oauth2_server`
- Changed psr7/17 definition ids: from FQCN to ids (which prevent unexpected behaviors if these ids are defined in the userland)