### PR TITLE
Improve update command

### DIFF
--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -21,9 +21,9 @@ Arguments:
   secret                             The client secret
 
 Options:
-      --redirect-uri[=REDIRECT-URI]  Sets redirect uri for client. Use this option multiple times to set multiple redirect URIs. (multiple values allowed)
-      --grant-type[=GRANT-TYPE]      Sets allowed grant type for client. Use this option multiple times to set multiple grant types. (multiple values allowed)
-      --scope[=SCOPE]                Sets allowed scope for client. Use this option multiple times to set multiple scopes. (multiple values allowed)
+      --redirect-uri=REDIRECT-URI    Sets redirect uri for client. Use this option multiple times to set multiple redirect URIs. (multiple values allowed)
+      --grant-type=GRANT-TYPE        Sets allowed grant type for client. Use this option multiple times to set multiple grant types. (multiple values allowed)
+      --scope=SCOPE                  Sets allowed scope for client. Use this option multiple times to set multiple scopes. (multiple values allowed)
       --public                       Creates a public client (a client which does not have a secret)
       --allow-plain-text-pkce        Creates a client which is allowed to create an authorization code grant PKCE request with the "plain" code challenge method
 ```
@@ -41,27 +41,17 @@ Usage:
   league:oauth2-server:update-client [options] [--] <identifier>
 
 Arguments:
-  identifier                         The client ID
+  identifier                                     The client identifier
 
 Options:
-      --redirect-uri[=REDIRECT-URI]  Sets redirect uri for client. Use this option multiple times to set multiple redirect URIs. (multiple values allowed)
-      --grant-type[=GRANT-TYPE]      Sets allowed grant type for client. Use this option multiple times to set multiple grant types. (multiple values allowed)
-      --scope[=SCOPE]                Sets allowed scope for client. Use this option multiple times to set multiple scopes. (multiple values allowed)
-      --name=[=NAME]                 Sets name for client.
-      --deactivated                  If provided, it will deactivate the given client.
-```
-
-#### Restrict which grant types a client can access
-
-```sh
-$ bin/console league:oauth2-server:update-client --grant-type client_credentials foo
-```
-
-#### Assign which scopes the client will receive
-
-
-```sh
-$ bin/console league:oauth2-server:update-client --scope create --scope read foo
+      --add-redirect-uri=ADD-REDIRECT-URI        Add allowed redirect uri to the client. (multiple values allowed)
+      --remove-redirect-uri=REMOVE-REDIRECT-URI  Remove allowed redirect uri to the client. (multiple values allowed)
+      --add-grant-type=ADD-GRANT-TYPE            Add allowed grant type to the client. (multiple values allowed)
+      --remove-grant-type=REMOVE-GRANT-TYPE      Remove allowed grant type to the client. (multiple values allowed)
+      --add-scope=ADD-SCOPE                      Add allowed scope to the client. (multiple values allowed)
+      --remove-scope=REMOVE-SCOPE                Remove allowed scope to the client. (multiple values allowed)
+      --activate                                 Activate the client.
+      --deactivate                               Deactivate the client.
 ```
 
 ### Delete a client
@@ -89,10 +79,10 @@ Usage:
   league:oauth2-server:list-clients [options]
 
 Options:
-      --columns[=COLUMNS]            Determine which columns are shown. Comma separated list. [default: "identifier, secret, scope, redirect uri, grant type"]
-      --redirect-uri[=REDIRECT-URI]  Finds by redirect uri for client. Use this option multiple times to filter by multiple redirect URIs. (multiple values allowed)
-      --grant-type[=GRANT-TYPE]      Finds by allowed grant type for client. Use this option multiple times to filter by multiple grant types. (multiple values allowed)
-      --scope[=SCOPE]                Finds by allowed scope for client. Use this option multiple times to find by multiple scopes. (multiple values allowed)__
+      --columns=COLUMNS              Determine which columns are shown. Comma separated list. [default: "identifier, secret, scope, redirect uri, grant type"]
+      --redirect-uri=REDIRECT-URI    Finds by redirect uri for client. Use this option multiple times to filter by multiple redirect URIs. (multiple values allowed)
+      --grant-type=GRANT-TYPE        Finds by allowed grant type for client. Use this option multiple times to filter by multiple grant types. (multiple values allowed)
+      --scope=SCOPE                  Finds by allowed scope for client. Use this option multiple times to find by multiple scopes. (multiple values allowed)__
 ```
 
 ## Configuring the Security layer

--- a/tests/Acceptance/UpdateClientCommandTest.php
+++ b/tests/Acceptance/UpdateClientCommandTest.php
@@ -6,100 +6,81 @@ namespace League\Bundle\OAuth2ServerBundle\Tests\Acceptance;
 
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\Model\Grant;
+use League\Bundle\OAuth2ServerBundle\Model\RedirectUri;
+use League\Bundle\OAuth2ServerBundle\Model\Scope;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class UpdateClientCommandTest extends AbstractAcceptanceTest
 {
-    public function testUpdateRedirectUris(): void
+    /**
+     * @dataProvider updateRelatedModelsDataProvider
+     */
+    public function testUpdateRelatedModels(string $argument, array $initial, array $toAdd, array $toRemove, array $expected, string $getter, string $setter): void
     {
         $client = $this->fakeAClient('foobar');
+        $client->{$setter}(...$initial);
+
         $this->getClientManager()->save($client);
-        $this->assertCount(0, $client->getRedirectUris());
+        $this->assertCount(\count($initial), $client->{$getter}());
 
         $command = $this->application->find('league:oauth2-server:update-client');
         $commandTester = new CommandTester($command);
         $commandTester->execute([
             'command' => $command->getName(),
             'identifier' => $client->getIdentifier(),
-            '--redirect-uri' => ['http://example.com', 'http://example.org'],
+            sprintf('--add-%s', $argument) => $toAdd,
+            sprintf('--remove-%s', $argument) => $toRemove,
         ]);
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('OAuth2 client updated successfully.', $output);
-        $this->assertCount(2, $client->getRedirectUris());
-    }
+        $this->assertEquals($expected, $client->{$getter}());
 
-    public function testUpdateGrantTypes(): void
-    {
-        $client = $this->fakeAClient('foobar');
-        $this->getClientManager()->save($client);
-        $this->assertCount(0, $client->getGrants());
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Cannot specify "%s" in either "--add-%2$s" and "--remove-%2$s".', $toAdd[0], $argument));
 
-        $command = $this->application->find('league:oauth2-server:update-client');
-        $commandTester = new CommandTester($command);
         $commandTester->execute([
             'command' => $command->getName(),
             'identifier' => $client->getIdentifier(),
-            '--grant-type' => ['password', 'client_credentials'],
+            sprintf('--add-%s', $argument) => [$toAdd[0]],
+            sprintf('--remove-%s', $argument) => [$toAdd[0]],
         ]);
-        $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('OAuth2 client updated successfully.', $output);
-        $this->assertCount(2, $client->getGrants());
     }
 
-    public function testUpdateScopes(): void
+    public function updateRelatedModelsDataProvider(): iterable
     {
-        $client = $this->fakeAClient('foobar');
-        $this->getClientManager()->save($client);
-        $this->assertCount(0, $client->getScopes());
+        yield 'redirect uris' => [
+            'redirect-uri',
+            [new RedirectUri('http://one.com'), new RedirectUri('http://two.com')],
+            ['http://three.com', 'http://four.com'],
+            ['http://one.com', 'http://five.com'],
+            [new RedirectUri('http://two.com'), new RedirectUri('http://three.com'), new RedirectUri('http://four.com')],
+            'getRedirectUris',
+            'setRedirectUris',
+        ];
 
-        $command = $this->application->find('league:oauth2-server:update-client');
-        $commandTester = new CommandTester($command);
-        $commandTester->execute([
-            'command' => $command->getName(),
-            'identifier' => $client->getIdentifier(),
-            '--scope' => ['foo', 'bar'],
-        ]);
-        $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('OAuth2 client updated successfully.', $output);
-        $this->assertCount(2, $client->getScopes());
+        yield 'grant types' => [
+            'grant-type',
+            [new Grant('one'), new Grant('two')],
+            ['three', 'four'],
+            ['one', 'five'],
+            [new Grant('two'), new Grant('three'), new Grant('four')],
+            'getGrants',
+            'setGrants',
+        ];
+
+        yield 'scopes' => [
+            'scope',
+            [new Scope('one'), new Scope('two')],
+            ['three', 'four'],
+            ['one', 'five'],
+            [new Scope('two'), new Scope('three'), new Scope('four')],
+            'getScopes',
+            'setScopes',
+        ];
     }
 
-    public function testUpdateName(): void
-    {
-        $client = $this->fakeAClient('foobar');
-        $this->getClientManager()->save($client);
-        $this->assertCount(0, $client->getRedirectUris());
-
-        $command = $this->application->find('league:oauth2-server:update-client');
-        $commandTester = new CommandTester($command);
-        $commandTester->execute([
-            'command' => $command->getName(),
-            'identifier' => $client->getIdentifier(),
-            '--name' => 'newName',
-        ]);
-        $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('OAuth2 client updated successfully.', $output);
-        $this->assertSame('newName', $client->getName());
-    }
-
-    public function testNameIsNotUpdatedIfNotSet(): void
-    {
-        $client = $this->fakeAClient('foobar');
-        $this->getClientManager()->save($client);
-        $this->assertSame('name', $client->getName());
-
-        $command = $this->application->find('league:oauth2-server:update-client');
-        $commandTester = new CommandTester($command);
-        $commandTester->execute([
-            'command' => $command->getName(),
-            'identifier' => $client->getIdentifier(),
-        ]);
-        $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('OAuth2 client updated successfully.', $output);
-        $this->assertSame('name', $client->getName());
-    }
-
-    public function testDeactivate(): void
+    public function testUpdateActive(): void
     {
         $client = $this->fakeAClient('foobar');
         $this->getClientManager()->save($client);
@@ -110,12 +91,32 @@ final class UpdateClientCommandTest extends AbstractAcceptanceTest
         $commandTester->execute([
             'command' => $command->getName(),
             'identifier' => $client->getIdentifier(),
-            '--deactivated' => true,
+            '--deactivate' => null,
         ]);
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('OAuth2 client updated successfully.', $output);
         $updatedClient = $this->getClientManager()->find($client->getIdentifier());
         $this->assertFalse($updatedClient->isActive());
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'identifier' => $client->getIdentifier(),
+            '--activate' => null,
+        ]);
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('OAuth2 client updated successfully.', $output);
+        $updatedClient = $this->getClientManager()->find($client->getIdentifier());
+        $this->assertTrue($updatedClient->isActive());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot specify "--activate" and "--deactivate" at the same time.');
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'identifier' => $client->getIdentifier(),
+            '--activate' => null,
+            '--deactivate' => null,
+        ]);
     }
 
     private function fakeAClient($identifier): Client


### PR DESCRIPTION
The previous command used to use the "set" way to deal with relationships.
As an example, `--scope` option was used to define every scope that will be linked to a client.
This meant that if the `--scope` option was not provided, the command thought that `[]` was the wanted scopes.

The new approach is to use the "add/remove" way instead.

I also added the possibility to activate a client (before we only could deactivate it)

So here is the new command behavior:
```
Description:
  Updates an oAuth2 client

Usage:
  league:oauth2-server:update-client [options] [--] <identifier>

Arguments:
  identifier                                     The client identifier

Options:
      --add-redirect-uri=ADD-REDIRECT-URI        Add allowed redirect uri to the client. (multiple values allowed)
      --remove-redirect-uri=REMOVE-REDIRECT-URI  Remove allowed redirect uri to the client. (multiple values allowed)
      --add-grant-type=ADD-GRANT-TYPE            Add allowed grant type to the client. (multiple values allowed)
      --remove-grant-type=REMOVE-GRANT-TYPE      Remove allowed grant type to the client. (multiple values allowed)
      --add-scope=ADD-SCOPE                      Add allowed scope to the client. (multiple values allowed)
      --remove-scope=REMOVE-SCOPE                Remove allowed scope to the client. (multiple values allowed)
      --activate                                 Activate the client.
      --deactivate                               Deactivate the client.
```