### PR TITLE
OAuth2Authenticator should only support Bearer authorizations

### DIFF
--- a/src/Security/Authenticator/OAuth2Authenticator.php
+++ b/src/Security/Authenticator/OAuth2Authenticator.php
@@ -64,7 +64,7 @@ final class OAuth2Authenticator implements AuthenticatorInterface, Authenticatio
 
     public function supports(Request $request): ?bool
     {
-        return null;
+        return 0 === strpos($request->headers->get('Authorization', ''), 'Bearer ');
     }
 
     public function start(Request $request, AuthenticationException $authException = null): Response

--- a/tests/Acceptance/SecurityLayerTest.php
+++ b/tests/Acceptance/SecurityLayerTest.php
@@ -149,7 +149,7 @@ final class SecurityLayerTest extends AbstractAcceptanceTest
 
         $response = $this->client->getResponse();
 
-        $this->assertSame(401, $response->getStatusCode());
-        $this->assertSame('Bearer', $response->headers->get('WWW-Authenticate'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Hello, guest', $response->getContent());
     }
 }

--- a/tests/Fixtures/SecurityTestController.php
+++ b/tests/Fixtures/SecurityTestController.php
@@ -28,7 +28,7 @@ final class SecurityTestController extends AbstractController
         $user = $this->getUser();
 
         return new Response(
-            sprintf('Hello, %s', $user instanceof NullUser ? 'guest' : (method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername()))
+            sprintf('Hello, %s', null === $user || $user instanceof NullUser ? 'guest' : (method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername()))
         );
     }
 

--- a/tests/Integration/AuthorizationServerTest.php
+++ b/tests/Integration/AuthorizationServerTest.php
@@ -312,7 +312,6 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         $response = $this->handleTokenRequest($request);
 
-        // Response assertions.
         $this->assertSame('invalid_grant', $response['error']);
     }
 


### PR DESCRIPTION
This fixes the problem that the client receives a `The resource server rejected the request.` when it tries to access a public endpoint (reported by #42).
Also potentially fixes conflicts when multiple authenticators are configured.