### PR TITLE
SuperClass AbstractClient can not have indentifier mapped

### DIFF
--- a/docs/using-custom-client.md
+++ b/docs/using-custom-client.md
@@ -14,14 +14,14 @@
     use Doctrine\ORM\Mapping as ORM;
     use League\Bundle\OAuth2ServerBundle\Model\AbstractClient;
 
-    /**
-     * @ORM\Entity
-     */
+    #[ORM\Entity]
     class Client extends AbstractClient
     {
-        /**
-         * @ORM\Column(type="string")
-         */
+        #[ORM\Id]
+        #[ORM\Column(type: 'string', length: 32)]
+        protected $identifier;
+
+        #[ORM\Column(type: 'string')]
         private $image;
 
         // other properties, getters, setters, ...

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\DependencyInjection;
 
-use Defuse\Crypto\Key;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use League\Bundle\OAuth2ServerBundle\AuthorizationServer\GrantTypeInterface;
 use League\Bundle\OAuth2ServerBundle\Command\CreateClientCommand;
@@ -16,7 +15,6 @@ use League\Bundle\OAuth2ServerBundle\Manager\Doctrine\AuthorizationCodeManager;
 use League\Bundle\OAuth2ServerBundle\Manager\Doctrine\ClientManager;
 use League\Bundle\OAuth2ServerBundle\Manager\Doctrine\RefreshTokenManager;
 use League\Bundle\OAuth2ServerBundle\Manager\ScopeManagerInterface;
-use League\Bundle\OAuth2ServerBundle\Model\Client;
 use League\Bundle\OAuth2ServerBundle\Model\Scope as ScopeModel;
 use League\Bundle\OAuth2ServerBundle\Persistence\Mapping\Driver;
 use League\Bundle\OAuth2ServerBundle\Security\Authenticator\OAuth2Authenticator;
@@ -268,7 +266,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
 
         $container
             ->findDefinition(Driver::class)
-            ->replaceArgument(0, Client::class !== $config['client']['classname'])
+            ->replaceArgument(0, $config['client']['classname'])
         ;
 
         $container->setParameter('league.oauth2_server.persistence.doctrine.enabled', true);

--- a/src/Model/AbstractClient.php
+++ b/src/Model/AbstractClient.php
@@ -19,7 +19,7 @@ abstract class AbstractClient
     /**
      * @var string
      */
-    private $identifier;
+    protected $identifier;
 
     /**
      * @var string|null


### PR DESCRIPTION
This is a fix for bug #45.

Turns out that AbstractClient is wrongly mapped.
Quoted from [Doctrine/ORM documentation](https://github.com/thephpleague/oauth2-server-bundle/compare/master...yoshz:bugfix/docrine-mapping):

> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations are only possible if the mapped superclass is only used in exactly one entity at the moment. For further support of inheritance, the single or joined table inheritance features have to be used.

So AbstractClient can not have an identifier and can not be used as an association between entities.