### PR TITLE
add request token event

### DIFF
--- a/src/Controller/TokenController.php
+++ b/src/Controller/TokenController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Controller;
 
+use League\Bundle\OAuth2ServerBundle\Event\TokenRequestResolveEvent;
+use League\Bundle\OAuth2ServerBundle\OAuth2Events;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -11,6 +13,7 @@ use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class TokenController
 {
@@ -34,16 +37,23 @@ final class TokenController
      */
     private $responseFactory;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
     public function __construct(
         AuthorizationServer $server,
         HttpMessageFactoryInterface $httpMessageFactory,
         HttpFoundationFactoryInterface $httpFoundationFactory,
-        ResponseFactoryInterface $responseFactory
+        ResponseFactoryInterface $responseFactory,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->server = $server;
         $this->httpMessageFactory = $httpMessageFactory;
         $this->httpFoundationFactory = $httpFoundationFactory;
         $this->responseFactory = $responseFactory;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function indexAction(Request $request): Response
@@ -57,6 +67,14 @@ final class TokenController
             $response = $e->generateHttpResponse($serverResponse);
         }
 
-        return $this->httpFoundationFactory->createResponse($response);
+        $renderedResponse = $this->httpFoundationFactory->createResponse($response);
+
+        /** @var TokenRequestResolveEvent $event */
+        $this->eventDispatcher->dispatch(
+            new TokenRequestResolveEvent($renderedResponse),
+            OAuth2Events::TOKEN_REQUEST_RESOLVE
+        );
+
+        return $renderedResponse;
     }
 }

--- a/src/Event/TokenRequestResolveEvent.php
+++ b/src/Event/TokenRequestResolveEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Bundle\OAuth2ServerBundle\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class TokenRequestResolveEvent extends Event
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    public function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+    public function setResponse(Response $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/src/OAuth2Events.php
+++ b/src/OAuth2Events.php
@@ -32,6 +32,14 @@ final class OAuth2Events
     public const AUTHORIZATION_REQUEST_RESOLVE = 'league.oauth2_server.event.authorization_request_resolve';
 
     /**
+     * The REQUEST_TOKEN_RESOLVE event occurs right before the system
+     * complete token request.
+     *
+     * You could manipulate the response.
+     */
+    public const TOKEN_REQUEST_RESOLVE = 'league.oauth2_server.event.token_request_resolve';
+
+    /**
      * The PRE_SAVE_CLIENT event occurs right before the client is saved
      * by a ClientManager.
      *

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -221,6 +221,7 @@ return static function (ContainerConfigurator $container): void {
                 service('league.oauth2_server.factory.psr_http'),
                 service('league.oauth2_server.factory.http_foundation'),
                 service('league.oauth2_server.factory.psr17'),
+                service('event_dispatcher'),
             ])
             ->tag('controller.service_arguments')
         ->alias(TokenController::class, 'league.oauth2_server.controller.token')


### PR DESCRIPTION
I've added an event to manipulate the response during /token process. Useful to add some Set-Cookie directives for example.