### PR TITLE
Add OAuth Client ID to OAuth2Token

### DIFF
--- a/src/Security/Authentication/Token/OAuth2Token.php
+++ b/src/Security/Authentication/Token/OAuth2Token.php
@@ -18,10 +18,12 @@ final class OAuth2Token extends AbstractToken
     public function __construct(
         ?UserInterface $user,
         string $accessTokenId,
+        string $oauthClientId,
         array $scopes,
         string $rolePrefix
     ) {
         $this->setAttribute('access_token_id', $accessTokenId);
+        $this->setAttribute('oauth_client_id', $oauthClientId);
         $this->setAttribute('scopes', $scopes);
 
         // Build roles from scope
@@ -53,5 +55,11 @@ final class OAuth2Token extends AbstractToken
     {
         /** @var string */
         return $this->getAttribute('access_token_id');
+    }
+
+    public function getOAuthClientId(): string
+    {
+        /** @var string */
+        return $this->getAttribute('oauth_client_id');
     }
 }

--- a/src/Security/Authenticator/OAuth2Authenticator.php
+++ b/src/Security/Authenticator/OAuth2Authenticator.php
@@ -92,6 +92,9 @@ final class OAuth2Authenticator implements AuthenticatorInterface, Authenticatio
         /** @var list<string> $scopes */
         $scopes = $psr7Request->getAttribute('oauth_scopes', []);
 
+        /** @var string $oauthClientId */
+        $oauthClientId = $psr7Request->getAttribute('oauth_client_id', '');
+
         $userLoader = function (string $userIdentifier): UserInterface {
             if ('' === $userIdentifier) {
                 return new NullUser();
@@ -108,6 +111,8 @@ final class OAuth2Authenticator implements AuthenticatorInterface, Authenticatio
         ]);
 
         $passport->setAttribute('accessTokenId', $accessTokenId);
+
+        $passport->setAttribute('oauthClientId', $oauthClientId);
 
         return $passport;
     }
@@ -127,7 +132,10 @@ final class OAuth2Authenticator implements AuthenticatorInterface, Authenticatio
         /** @var ScopeBadge $scopeBadge */
         $scopeBadge = $passport->getBadge(ScopeBadge::class);
 
-        $token = new OAuth2Token($passport->getUser(), $accessTokenId, $scopeBadge->getScopes(), $this->rolePrefix);
+        /** @var string $oauthClientId */
+        $oauthClientId = $passport->getAttribute('oauthClientId');
+
+        $token = new OAuth2Token($passport->getUser(), $accessTokenId, $oauthClientId, $scopeBadge->getScopes(), $this->rolePrefix);
         $token->setAuthenticated(true);
 
         return $token;

--- a/tests/Unit/OAuth2AuthenticatorTest.php
+++ b/tests/Unit/OAuth2AuthenticatorTest.php
@@ -143,6 +143,7 @@ final class OAuth2AuthenticatorTest extends TestCase
             new ScopeBadge(['scope_one', 'scope_two']),
         ]);
         $passport->setAttribute('accessTokenId', 'accessTokenId');
+        $passport->setAttribute('oauthClientId', 'oauthClientId');
 
         $authenticator = new OAuth2Authenticator(
             $this->createMock(HttpMessageFactoryInterface::class),

--- a/tests/Unit/OAuth2TokenTest.php
+++ b/tests/Unit/OAuth2TokenTest.php
@@ -15,16 +15,18 @@ final class OAuth2TokenTest extends TestCase
     {
         $user = new User();
         $accessTokenId = 'accessTokenId';
+        $oauthClientId = 'oauthClientId';
         $scopes = [FixtureFactory::FIXTURE_SCOPE_FIRST];
         $rolePrefix = 'ROLE_OAUTH2_';
 
-        $token = new OAuth2Token($user, $accessTokenId, $scopes, $rolePrefix);
+        $token = new OAuth2Token($user, $accessTokenId, $oauthClientId, $scopes, $rolePrefix);
 
         /** @var OAuth2Token $unserializedToken */
         $unserializedToken = unserialize(serialize($token));
 
         $this->assertSame($user->getUsername(), $unserializedToken->getUser()->getUsername());
         $this->assertSame($accessTokenId, $token->getCredentials());
+        $this->assertSame($oauthClientId, $token->getOAuthClientId());
         $this->assertSame($scopes, $token->getScopes());
         $this->assertSame([sprintf('%s%s', $rolePrefix, strtoupper($scopes[0]))], $token->getRoleNames());
 


### PR DESCRIPTION
This PR should help with issue #50. It adds Client ID to the Passport and Token.

This way the client can be retrieved like this:
```
$clientId = $this->security->getToken()->getOAuthClientId();
$userRepository->findOneByClientId($clientId);
```