### PR TITLE
Fix debugging docs

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -7,12 +7,12 @@ Before you start you'll need to setup your IDE, the following is an example in P
 Then all you need to do is run the following command:
 
 ```sh
-dev/bin/php-debug vendor/bin/phpunit
+dev/bin/php-debug vendor/bin/simple-phpunit
 ```
 
 If you wish to use a different server name, you can do this with the
 `PHP_IDE_CONFIG` env variable:
 
 ```sh
-PHP_IDE_CONFIG=some_other_name dev/bin/php-debug vendor/bin/phpunit
+PHP_IDE_CONFIG=some_other_name dev/bin/php-debug vendor/bin/simple-phpunit
 ```


### PR DESCRIPTION
This PR updates the debugging docs to reflect that PHPUnit is no longer a `require-dev` dependency and that simple PHPUnit is used instead.