### PR TITLE
Update test matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,27 +10,30 @@ jobs:
             fail-fast: false
             matrix:
                 #Stable supported versions
-                php: ['7.3', '7.4', '8.0', '8.1']
-                symfony: ['5.3.*', '5.4.*']
+                php: ['7.4', '8.0', '8.1']
+                symfony: ['5.3.*', '5.4.*', '6.0.*']
                 composer-flags: ['--prefer-stable']
                 can-fail: [false]
+                exclude:
+                    - php: '7.4'
+                      symfony: '6.0.*'
                 include:
                     # Lowest supported versions
                     - php: '7.2'
                       symfony: '5.3.*'
                       composer-flags: '--prefer-stable --prefer-lowest'
                       can-fail: false
-                    # Symfony 6
-                    - php: '8.0'
-                      symfony: '6.0.*'
+                    # EOL PHP versions
+                    - php: '7.2'
+                      symfony: '5.4.*'
                       composer-flags: '--prefer-stable'
                       can-fail: false
-                    - php: '8.1'
-                      symfony: '6.0.*'
+                    - php: '7.3'
+                      symfony: '5.4.*'
                       composer-flags: '--prefer-stable'
                       can-fail: false
                     # Development versions
-                    - php: '8.1-rc'
+                    - php: '8.1'
                       symfony: '6.1.x-dev'
                       composer-flags: ''
                       can-fail: false


### PR DESCRIPTION
Update the tests matrix with the latest versions of PHP and Symfony

The PHP 8.1 docker image is not available yet and support of PHP 7.3 will be dropped in 6 days. I will update the PR and I will mark it as ready for review when this happens.