### PR TITLE
Make sure token is always authenticated

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,8 +10,8 @@ jobs:
             fail-fast: false
             matrix:
                 #Stable supported versions
-                php: ['7.3', '7.4', '8.0']
-                symfony: ['5.3.*']
+                php: ['7.3', '7.4', '8.0', '8.1']
+                symfony: ['5.3.*', '5.4.*']
                 composer-flags: ['--prefer-stable']
                 can-fail: [false]
                 include:
@@ -20,13 +20,18 @@ jobs:
                       symfony: '5.3.*'
                       composer-flags: '--prefer-stable --prefer-lowest'
                       can-fail: false
+                    # Symfony 6
+                    - php: '8.0'
+                      symfony: '6.0.*'
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
+                    - php: '8.1'
+                      symfony: '6.0.*'
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
                     # Development versions
                     - php: '8.1-rc'
-                      symfony: '5.4.x-dev'
-                      composer-flags: ''
-                      can-fail: false
-                    - php: '8.1-rc'
-                      symfony: '6.0.x-dev'
+                      symfony: '6.1.x-dev'
                       composer-flags: ''
                       can-fail: false
 

--- a/src/Security/Authenticator/OAuth2Authenticator.php
+++ b/src/Security/Authenticator/OAuth2Authenticator.php
@@ -157,6 +157,11 @@ final class OAuth2Authenticator implements AuthenticatorInterface, Authenticatio
         $oauthClientId = $passport->getAttribute('oauthClientId', '');
 
         $token = new OAuth2Token($passport->getUser(), $accessTokenId, $oauthClientId, $scopeBadge->getScopes(), $this->rolePrefix);
+        if (method_exists(AuthenticatorInterface::class, 'createAuthenticatedToken') && !method_exists(AuthenticatorInterface::class, 'createToken')) {
+            // symfony 5.4 only
+            /** @psalm-suppress TooManyArguments */
+            $token->setAuthenticated(true, false);
+        }
 
         return $token;
     }


### PR DESCRIPTION
After upgrading to symfony 5.4, authorization is broken because the OAuth2Token doesn't is "authenticated" anymore (see #68).
From symfony 5.4 on the `authenticated` property is not used anymore but triggers an error in the AuthorizationChecker when it is false (this seems buggy as well).

This fix ensures the authenticated property is always true when an user is set on the token.
~~This is the same behavior as the UsernamePasswordToken and RememberMeToken.~~
Seems this fix is only necessary for symfony 5.4. Symfony 6.0 works fine.

I have updated the pipeline config to tests on the right versions and update composer to v2 as it is required for symfony 6.0.
