### PR TITLE
Add authorization tests

### DIFF
--- a/tests/Fixtures/SecurityTestController.php
+++ b/tests/Fixtures/SecurityTestController.php
@@ -48,4 +48,11 @@ final class SecurityTestController extends AbstractController
             )
         );
     }
+
+    public function authorizationAction(): Response
+    {
+        $this->denyAccessUnlessGranted('ROLE_OAUTH2_FANCY');
+
+        return new Response('access granted');
+    }
 }

--- a/tests/Fixtures/routes.php
+++ b/tests/Fixtures/routes.php
@@ -23,5 +23,8 @@ return function (RoutingConfigurator $routes) {
         ->defaults([
             'oauth2_scopes' => ['fancy'],
         ])
+
+        ->add('security_test_authorization', '/security-test-authorization')
+        ->controller([SecurityTestController::class, 'authorizationAction'])
     ;
 };


### PR DESCRIPTION
This PR adds a regression test which was previously missing (it checks that the bundle integrates properly with Symfony authorization).

This test is failing on Symfony 5.4 without the changes that were made in https://github.com/thephpleague/oauth2-server-bundle/pull/72 so it's needed to prove that the bundle works as intended after that change was made.