### PR TITLE
Register commands by adding the AsCommand attribute

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,16 +23,12 @@ jobs:
                       symfony: '6.1.*'
                 include:
                     # Lowest supported versions
-                    - php: '7.2'
+                    - php: '8.0'
                       symfony: '5.3.*'
                       composer-flags: '--prefer-stable --prefer-lowest'
                       can-fail: false
                     # EOL PHP versions
-                    - php: '7.2'
-                      symfony: '5.4.*'
-                      composer-flags: '--prefer-stable'
-                      can-fail: false
-                    - php: '7.3'
+                    - php: 8.0'
                       symfony: '5.4.*'
                       composer-flags: '--prefer-stable'
                       can-fail: false

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "doctrine/doctrine-bundle": "^2.0.8",
         "doctrine/orm": "^2.7.1",
         "league/oauth2-server": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.0",
         "doctrine/doctrine-bundle": "^2.0.8",
         "doctrine/orm": "^2.7.1",
         "league/oauth2-server": "^8.3",

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 
 FROM php:${PHP_VERSION}-cli-alpine
 LABEL maintainer="Petar Obradović <petar.obradovic@trikoder.net>"

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ For implementation into Symfony projects, please see [bundle documentation](basi
 
 ## Requirements
 
-* [PHP 7.2](http://php.net/releases/7_2_0.php) or greater
+* [PHP 8.0](https://www.php.net/releases/8_0_0.php) or greater
 * [Symfony 5.2](https://symfony.com/roadmap/5.2) or greater
 
 ## Installation

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,7 @@
 <psalm
     errorLevel="1"
     strictBinaryOperands="true"
-    phpVersion="7.2"
+    phpVersion="8.0"
     allowStringToStandInForClass="true"
     rememberPropertyAssignmentsAfterCall="false"
     checkForThrowsInGlobalScope="true"

--- a/src/Command/ClearExpiredTokensCommand.php
+++ b/src/Command/ClearExpiredTokensCommand.php
@@ -7,16 +7,16 @@ namespace League\Bundle\OAuth2ServerBundle\Command;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AuthorizationCodeManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\RefreshTokenManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:clear-expired-tokens')]
 final class ClearExpiredTokensCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:clear-expired-tokens';
-
     /**
      * @var AccessTokenManagerInterface
      */

--- a/src/Command/CreateClientCommand.php
+++ b/src/Command/CreateClientCommand.php
@@ -9,6 +9,7 @@ use League\Bundle\OAuth2ServerBundle\Model\AbstractClient;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -16,10 +17,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:create-client')]
 final class CreateClientCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:create-client';
-
     /**
      * @var ClientManagerInterface
      */

--- a/src/Command/CreateClientCommand.php
+++ b/src/Command/CreateClientCommand.php
@@ -121,7 +121,6 @@ final class CreateClientCommand extends Command
     {
         $name = $input->getArgument('name');
 
-        /** @var string $identifier */
         $identifier = $input->getArgument('identifier') ?? hash('md5', random_bytes(16));
 
         $isPublic = $input->getOption('public');

--- a/src/Command/DeleteClientCommand.php
+++ b/src/Command/DeleteClientCommand.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace League\Bundle\OAuth2ServerBundle\Command;
 
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:delete-client')]
 final class DeleteClientCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:delete-client';
-
     /**
      * @var ClientManagerInterface
      */

--- a/src/Command/ListClientsCommand.php
+++ b/src/Command/ListClientsCommand.php
@@ -10,17 +10,17 @@ use League\Bundle\OAuth2ServerBundle\Model\AbstractClient;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:list-clients')]
 final class ListClientsCommand extends Command
 {
     private const ALLOWED_COLUMNS = ['name', 'identifier', 'secret', 'scope', 'redirect uri', 'grant type'];
-
-    protected static $defaultName = 'league:oauth2-server:list-clients';
 
     /**
      * @var ClientManagerInterface

--- a/src/Command/UpdateClientCommand.php
+++ b/src/Command/UpdateClientCommand.php
@@ -8,6 +8,7 @@ use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,10 +16,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:update-client')]
 final class UpdateClientCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:update-client';
-
     /**
      * @var ClientManagerInterface
      */


### PR DESCRIPTION
This PR is addressing the following deprecation warnings that I'm getting when using Symfony 6.1 and the latest version of the oauth2 server bundle.
```
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\CreateClientCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\UpdateClientCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\DeleteClientCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\ListClientsCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\ClearExpiredTokensCommand" class instead.
```

In all Commands, I have replaced the deprecated static property "$defaultName" with the `AsCommand` attribute. As a result of this change, I also had to upgrade the minimum PHP version allowed from 7.2 to 8.0.