### PR TITLE
Fix deprecation warnings in commands

### DIFF
--- a/src/Command/ClearExpiredTokensCommand.php
+++ b/src/Command/ClearExpiredTokensCommand.php
@@ -15,8 +15,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class ClearExpiredTokensCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:clear-expired-tokens';
-
     /**
      * @var AccessTokenManagerInterface
      */

--- a/src/Command/ClearExpiredTokensCommand.php
+++ b/src/Command/ClearExpiredTokensCommand.php
@@ -7,12 +7,14 @@ namespace League\Bundle\OAuth2ServerBundle\Command;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AuthorizationCodeManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\RefreshTokenManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:clear-expired-tokens', description: 'Clears all expired access and/or refresh tokens and/or auth codes')]
 final class ClearExpiredTokensCommand extends Command
 {
     /**

--- a/src/Command/CreateClientCommand.php
+++ b/src/Command/CreateClientCommand.php
@@ -9,6 +9,7 @@ use League\Bundle\OAuth2ServerBundle\Model\AbstractClient;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -16,6 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:create-client', description: 'Creates a new OAuth2 client')]
 final class CreateClientCommand extends Command
 {
     /**

--- a/src/Command/CreateClientCommand.php
+++ b/src/Command/CreateClientCommand.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class CreateClientCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:create-client';
-
     /**
      * @var ClientManagerInterface
      */

--- a/src/Command/DeleteClientCommand.php
+++ b/src/Command/DeleteClientCommand.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace League\Bundle\OAuth2ServerBundle\Command;
 
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:delete-client', description: 'Deletes an OAuth2 client')]
 final class DeleteClientCommand extends Command
 {
     /**

--- a/src/Command/DeleteClientCommand.php
+++ b/src/Command/DeleteClientCommand.php
@@ -13,8 +13,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class DeleteClientCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:delete-client';
-
     /**
      * @var ClientManagerInterface
      */

--- a/src/Command/ListClientsCommand.php
+++ b/src/Command/ListClientsCommand.php
@@ -10,12 +10,14 @@ use League\Bundle\OAuth2ServerBundle\Model\AbstractClient;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:list-clients', description: 'Lists existing OAuth2 clients')]
 final class ListClientsCommand extends Command
 {
     private const ALLOWED_COLUMNS = ['name', 'identifier', 'secret', 'scope', 'redirect uri', 'grant type'];
@@ -35,7 +37,7 @@ final class ListClientsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Lists existing oAuth2 clients')
+            ->setDescription('Lists existing OAuth2 clients')
             ->addOption(
                 'columns',
                 null,

--- a/src/Command/ListClientsCommand.php
+++ b/src/Command/ListClientsCommand.php
@@ -20,8 +20,6 @@ final class ListClientsCommand extends Command
 {
     private const ALLOWED_COLUMNS = ['name', 'identifier', 'secret', 'scope', 'redirect uri', 'grant type'];
 
-    protected static $defaultName = 'league:oauth2-server:list-clients';
-
     /**
      * @var ClientManagerInterface
      */

--- a/src/Command/UpdateClientCommand.php
+++ b/src/Command/UpdateClientCommand.php
@@ -8,6 +8,7 @@ use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,6 +16,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'league:oauth2-server:update-client', description: 'Updates an OAuth2 client')]
 final class UpdateClientCommand extends Command
 {
     /**

--- a/src/Command/UpdateClientCommand.php
+++ b/src/Command/UpdateClientCommand.php
@@ -17,8 +17,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class UpdateClientCommand extends Command
 {
-    protected static $defaultName = 'league:oauth2-server:update-client';
-
     /**
      * @var ClientManagerInterface
      */

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -235,28 +235,28 @@ return static function (ContainerConfigurator $container): void {
                 service(ClientManagerInterface::class),
                 null,
             ])
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'league:oauth2-server:create-client'])
         ->alias(CreateClientCommand::class, 'league.oauth2_server.command.create_client')
 
         ->set('league.oauth2_server.command.update_client', UpdateClientCommand::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'league:oauth2-server:update-client'])
         ->alias(UpdateClientCommand::class, 'league.oauth2_server.command.update_client')
 
         ->set('league.oauth2_server.command.delete_client', DeleteClientCommand::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'league:oauth2-server:delete-client'])
         ->alias(DeleteClientCommand::class, 'league.oauth2_server.command.delete_client')
 
         ->set('league.oauth2_server.command.list_clients', ListClientsCommand::class)
             ->args([
                 service(ClientManagerInterface::class),
             ])
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'league:oauth2-server:list-clients'])
         ->alias(ListClientsCommand::class, 'league.oauth2_server.command.list_clients')
 
         ->set('league.oauth2_server.command.clear_expired_tokens', ClearExpiredTokensCommand::class)
@@ -265,7 +265,7 @@ return static function (ContainerConfigurator $container): void {
                 service(RefreshTokenManagerInterface::class),
                 service(AuthorizationCodeManagerInterface::class),
             ])
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'league:oauth2-server:clear-expired-tokens'])
         ->alias(ClearExpiredTokensCommand::class, 'league.oauth2_server.command.clear_expired_tokens')
 
         // Utility services


### PR DESCRIPTION
This PR a follow up of #105 and it's addressing the following deprecation warnings that I'm getting when using Symfony 6.1 and the latest version of the oauth2 server bundle.

```
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\CreateClientCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\UpdateClientCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\DeleteClientCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\ListClientsCommand" class instead.
2022-10-13T07:48:25+00:00 [info] User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "League\Bundle\OAuth2ServerBundle\Command\ClearExpiredTokensCommand" class instead.
```