### PR TITLE
Update firewall config in basic-setup.md

### DIFF
--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -95,7 +95,7 @@ security:
 
     firewalls:
         api_token:
-            pattern: ^/api/token$
+            pattern: ^/token$
             security: false
         api:
             pattern: ^/api


### PR DESCRIPTION
Fixes issue #80 
The default configured route is /token, this is the firewall exception for /api/token, which doesn't match.