### PR TITLE
Allow custom table prefix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,9 @@ For implementation into Symfony projects, please see [bundle documentation](basi
 
                 # Name of the entity manager that you wish to use for managing clients and tokens.
                 entity_manager:       default
+
+                # Table name prefix.
+                table_prefix:         oauth2_
             in_memory:            ~
 
         # Set a custom prefix that replaces the default 'ROLE_OAUTH2_' role prefix

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -184,6 +184,11 @@ final class Configuration implements ConfigurationInterface
                             ->cannotBeEmpty()
                             ->defaultValue('default')
                         ->end()
+                        ->scalarNode('table_prefix')
+                            ->info('Table name prefix.')
+                            ->cannotBeEmpty()
+                            ->defaultValue('oauth2_')
+                        ->end()
                     ->end()
                 ->end()
                 // In-memory persistence

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -280,6 +280,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
             ->findDefinition(Driver::class)
             ->replaceArgument(0, $config['client']['classname'])
             ->replaceArgument(1, $config['authorization_server']['persist_access_token'])
+            ->replaceArgument(2, $persistenceConfig['table_prefix'])
         ;
 
         $container->setParameter('league.oauth2_server.persistence.doctrine.enabled', true);

--- a/src/Persistence/Mapping/Driver.php
+++ b/src/Persistence/Mapping/Driver.php
@@ -28,10 +28,14 @@ class Driver implements MappingDriver
     /** @var bool */
     private $persistAccessToken;
 
-    public function __construct(string $clientClass, bool $persistAccessToken)
+    /** @var string */
+    private $tablePrefix;
+
+    public function __construct(string $clientClass, bool $persistAccessToken, string $tablePrefix = 'oauth2_')
     {
         $this->clientClass = $clientClass;
         $this->persistAccessToken = $persistAccessToken;
+        $this->tablePrefix = $tablePrefix;
     }
 
     public function loadMetadataForClass($className, ClassMetadata $metadata): void
@@ -97,7 +101,7 @@ class Driver implements MappingDriver
     private function buildAccessTokenMetadata(ClassMetadata $metadata): void
     {
         (new ClassMetadataBuilder($metadata))
-            ->setTable('oauth2_access_token')
+            ->setTable($this->tablePrefix . 'access_token')
             ->createField('identifier', 'string')->makePrimaryKey()->length(80)->option('fixed', true)->build()
             ->addField('expiry', 'datetime_immutable')
             ->createField('userIdentifier', 'string')->length(128)->nullable(true)->build()
@@ -110,7 +114,7 @@ class Driver implements MappingDriver
     private function buildAuthorizationCodeMetadata(ClassMetadata $metadata): void
     {
         (new ClassMetadataBuilder($metadata))
-            ->setTable('oauth2_authorization_code')
+            ->setTable($this->tablePrefix . 'authorization_code')
             ->createField('identifier', 'string')->makePrimaryKey()->length(80)->option('fixed', true)->build()
             ->addField('expiry', 'datetime_immutable')
             ->createField('userIdentifier', 'string')->length(128)->nullable(true)->build()
@@ -123,7 +127,7 @@ class Driver implements MappingDriver
     private function buildClientMetadata(ClassMetadata $metadata): void
     {
         (new ClassMetadataBuilder($metadata))
-            ->setTable('oauth2_client')
+            ->setTable($this->tablePrefix . 'client')
             ->createField('identifier', 'string')->makePrimaryKey()->length(32)->build()
         ;
     }
@@ -131,7 +135,7 @@ class Driver implements MappingDriver
     private function buildRefreshTokenMetadata(ClassMetadata $metadata): void
     {
         $classMetadataBuilder = (new ClassMetadataBuilder($metadata))
-            ->setTable('oauth2_refresh_token')
+            ->setTable($this->tablePrefix . 'refresh_token')
             ->createField('identifier', 'string')->makePrimaryKey()->length(80)->option('fixed', true)->build()
             ->addField('expiry', 'datetime_immutable')
             ->addField('revoked', 'boolean')

--- a/src/Resources/config/storage/doctrine.php
+++ b/src/Resources/config/storage/doctrine.php
@@ -25,6 +25,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 null,
                 null,
+                null,
             ])
         ->alias(Driver::class, 'league.oauth2_server.persistence.driver')
 


### PR DESCRIPTION
I need to configure the table name in order to store oauth2  data in a custom PostgreSQL schema, so I'd like to have the option to configure the table name prefix.

What do you think?