### PR TITLE
Fix Symfony 6.2 deprecation for Security helper

### DIFF
--- a/src/EventListener/AuthorizationRequestUserResolvingListener.php
+++ b/src/EventListener/AuthorizationRequestUserResolvingListener.php
@@ -4,30 +4,43 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\EventListener;
 
-use League\Bundle\OAuth2ServerBundle\Event\AuthorizationRequestResolveEvent;
-use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Bundle\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as LegacySecurity;
 
-/**
- * Listener sets currently authenticated user to authorization request context
- */
-final class AuthorizationRequestUserResolvingListener
-{
+if (class_exists(Security::class)) {
     /**
-     * @var Security
+     * Listener sets currently authenticated user to authorization request context
      */
-    private $security;
-
-    public function __construct(Security $security)
+    final class AuthorizationRequestUserResolvingListener
     {
-        $this->security = $security;
+        use AuthorizationRequestUserResolvingListenerTrait;
+
+        /**
+         * @var Security
+         */
+        private $security;
+
+        public function __construct(Security $security)
+        {
+            $this->security = $security;
+        }
     }
-
-    public function onAuthorizationRequest(AuthorizationRequestResolveEvent $event): void
+} else {
+    /**
+     * Listener sets currently authenticated user to authorization request context
+     */
+    final class AuthorizationRequestUserResolvingListener
     {
-        $user = $this->security->getUser();
-        if ($user instanceof UserInterface) {
-            $event->setUser($user);
+        use AuthorizationRequestUserResolvingListenerTrait;
+
+        /**
+         * @var LegacySecurity
+         */
+        private $security;
+
+        public function __construct(LegacySecurity $security)
+        {
+            $this->security = $security;
         }
     }
 }

--- a/src/EventListener/AuthorizationRequestUserResolvingListenerTrait.php
+++ b/src/EventListener/AuthorizationRequestUserResolvingListenerTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace League\Bundle\OAuth2ServerBundle\EventListener;
+
+use League\Bundle\OAuth2ServerBundle\Event\AuthorizationRequestResolveEvent;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+trait AuthorizationRequestUserResolvingListenerTrait
+{
+    public function onAuthorizationRequest(AuthorizationRequestResolveEvent $event): void
+    {
+        $user = $this->security->getUser();
+        if ($user instanceof UserInterface) {
+            $event->setUser($user);
+        }
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -57,7 +57,6 @@ use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
@@ -208,7 +207,7 @@ return static function (ContainerConfigurator $container): void {
         // Authorization listeners
         ->set('league.oauth2_server.listener.authorization_request_user_resolving', AuthorizationRequestUserResolvingListener::class)
             ->args([
-                service(Security::class),
+                service('security.helper'),
             ])
             ->tag('kernel.event_listener', [
                 'event' => OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE,


### PR DESCRIPTION
As the title states :) In Symfony 6.2 the Security helper of the Security component has been marked as deprecated, with a replacement helper being added in the Security bundle. This change fixes the deprecation by referencing the service by the name (`security.helper`) instead of the FQN, and for the "user" two implementations are added, one depending on the old class and one depending on the new class.

Tested on PHP 7.2 and 8.1 using both high and low dependencies.