### PR TITLE
Remove deprecated registration of entity namespace

### DIFF
--- a/src/DependencyInjection/CompilerPass/RegisterDoctrineOrmMappingPass.php
+++ b/src/DependencyInjection/CompilerPass/RegisterDoctrineOrmMappingPass.php
@@ -19,8 +19,7 @@ class RegisterDoctrineOrmMappingPass extends DoctrineOrmMappingsPass
             new Reference(Driver::class),
             ['League\Bundle\OAuth2ServerBundle\Model'],
             ['league.oauth2_server.persistence.doctrine.manager'],
-            'league.oauth2_server.persistence.doctrine.enabled',
-            ['LeagueOAuth2ServerBundle' => 'League\Bundle\OAuth2ServerBundle\Model']
+            'league.oauth2_server.persistence.doctrine.enabled'
         );
     }
 }


### PR DESCRIPTION
Registration of entity namespaces has been deprecated in doctrine/persistence 2.x and prevents usage of the bundle in combination with doctrine/persistence 3.x. This patch addresses #135 