### PR TITLE
Make OAuth2Token non-final

### DIFF
--- a/src/Security/Authentication/Token/OAuth2Token.php
+++ b/src/Security/Authentication/Token/OAuth2Token.php
@@ -10,7 +10,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class OAuth2Token extends AbstractToken
+class OAuth2Token extends AbstractToken
 {
     /**
      * @param list<string> $scopes


### PR DESCRIPTION
This - seemingly for no reason - prevents advanced use cases like extending the OAuth2Token with additional custom data.

There's a precedent in that Symfony themselves do not mark any Token classes as final and even extend them themselves.