### PR TITLE
Add extensibility point for custom storage managers

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -194,6 +194,10 @@ final class Configuration implements ConfigurationInterface
                 // In-memory persistence
                 ->scalarNode('in_memory')
                 ->end()
+                // Extensibility point
+                ->scalarNode('custom')
+                    ->cannotBeEmpty()
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -238,7 +238,11 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
                 $loader->load('storage/doctrine.php');
                 $this->configureDoctrinePersistence($container, $config, $persistenceConfig);
                 break;
+            case 'custom':
+                $persistenceMethod = $persistenceConfig;
         }
+
+        $container->setParameter('league.oauth2_server.persistence.method', $persistenceMethod);
     }
 
     private function configureDoctrinePersistence(ContainerBuilder $container, array $config, array $persistenceConfig): void

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -240,6 +240,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
                 break;
             case 'custom':
                 $persistenceMethod = $persistenceConfig;
+                break;
         }
 
         $container->setParameter('league.oauth2_server.persistence.method', $persistenceMethod);


### PR DESCRIPTION
Bundle provides abstraction for custom mangers but it is actually not possible to plug in custom, non-Doctrine storage due to rigid Configuration (it only allows to define either `in_memory` or `doctrine` as persistence methods).

This simple workaround provides third option `custom` and exposes persistence method as a parameter. Intention is to be able to detect which persistence method is currently set in CompilerPass and declare proper service aliases.

Usage example:

```yaml
league_oauth2_server:
    # ...
    persistence:
        custom: ibexa
```

```php
$container->getParameter('league.oauth2_server.persistence.method'); // ibexa
```

Without extension point we would have to brute-force custom services regardless of actual configuration.