### PR TITLE
Fix order of converting user

### DIFF
--- a/src/Controller/AuthorizationController.php
+++ b/src/Controller/AuthorizationController.php
@@ -101,11 +101,11 @@ final class AuthorizationController
                 OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE
             );
 
-            $authRequest->setUser($this->userConverter->toLeague($event->getUser()));
-
             if ($response = $event->getResponse()) {
                 return $response;
             }
+
+            $authRequest->setUser($this->userConverter->toLeague($event->getUser()));
 
             $authRequest->setAuthorizationApproved($event->getAuthorizationResolution());
 


### PR DESCRIPTION
Only convert the user from Symfony to League when no response is set on the event. As conversion doesn't / shouldn't have any side effects and the AuthorizationRequest isn't stored either (when a response is set) this should be safe.
This helps in those cases where no user is logged in / resolved, but one of the listeners sets a redirect. Otherwise the converter will be called with a null value and has to return a proper value (can't be null) for no obvious reason except to satisfy the interface.