### PR TITLE
Allow modifying scopes in AuthorizationRequestResolveEvent

### DIFF
--- a/src/Controller/AuthorizationController.php
+++ b/src/Controller/AuthorizationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Controller;
 
+use League\Bundle\OAuth2ServerBundle\Converter\ScopeConverterInterface;
 use League\Bundle\OAuth2ServerBundle\Converter\UserConverterInterface;
 use League\Bundle\OAuth2ServerBundle\Event\AuthorizationRequestResolveEventFactory;
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
@@ -41,6 +42,11 @@ final class AuthorizationController
     private $userConverter;
 
     /**
+     * @var ScopeConverterInterface
+     */
+    private $scopeConverter;
+
+    /**
      * @var ClientManagerInterface
      */
     private $clientManager;
@@ -65,6 +71,7 @@ final class AuthorizationController
         EventDispatcherInterface $eventDispatcher,
         AuthorizationRequestResolveEventFactory $eventFactory,
         UserConverterInterface $userConverter,
+        ScopeConverterInterface $scopeConverter,
         ClientManagerInterface $clientManager,
         HttpMessageFactoryInterface $httpMessageFactory,
         HttpFoundationFactoryInterface $httpFoundationFactory,
@@ -74,6 +81,7 @@ final class AuthorizationController
         $this->eventDispatcher = $eventDispatcher;
         $this->eventFactory = $eventFactory;
         $this->userConverter = $userConverter;
+        $this->scopeConverter = $scopeConverter;
         $this->clientManager = $clientManager;
         $this->httpMessageFactory = $httpMessageFactory;
         $this->httpFoundationFactory = $httpFoundationFactory;
@@ -102,6 +110,7 @@ final class AuthorizationController
             );
 
             $authRequest->setUser($this->userConverter->toLeague($event->getUser()));
+            $authRequest->setScopes($this->scopeConverter->toLeagueArray($event->getScopes()));
 
             if ($response = $event->getResponse()) {
                 return $response;

--- a/src/Event/AuthorizationRequestResolveEvent.php
+++ b/src/Event/AuthorizationRequestResolveEvent.php
@@ -122,6 +122,16 @@ final class AuthorizationRequestResolveEvent extends Event
         return $this->scopes;
     }
 
+    /**
+     * @param Scope[] $scopes
+     */
+    public function setScopes(array $scopes): self
+    {
+        $this->scopes = $scopes;
+
+        return $this;
+    }
+
     public function isAuthorizationApproved(): bool
     {
         return $this->authorizationRequest->isAuthorizationApproved();

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -196,6 +196,7 @@ return static function (ContainerConfigurator $container): void {
                 service(EventDispatcherInterface::class),
                 service(AuthorizationRequestResolveEventFactory::class),
                 service(UserConverterInterface::class),
+                service(ScopeConverterInterface::class),
                 service(ClientManagerInterface::class),
                 service('league.oauth2_server.factory.psr_http'),
                 service('league.oauth2_server.factory.http_foundation'),


### PR DESCRIPTION
Sometimes there's a need to allow the user to select optional scopes to allow or exclude from any given AuthorizationRequest.

We already have a good event to hook into to let the user decide whether they want to permit an OAuth connection or not, but there is no option in this (or later) event to modify the scopes.

This PR attempts to address that.