### PR TITLE
ci: Introduce a meta job for the tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,3 +77,21 @@ jobs:
 
             - name: "run unit tests"
               run: "vendor/bin/simple-phpunit --colors=always"
+
+
+    # This is a "trick", a meta task which does not change, and we can use in
+    # the protected branch rules as opposed to the individual tests which
+    # may change regularly.
+    validate-tests:
+        name: tests status
+        runs-on: ubuntu-latest
+        needs: [ tests ]
+        if: always()
+        steps:
+            - name: Successful run
+              if: ${{ !(contains(needs.*.result, 'failure')) }}
+              run: exit 0
+
+            - name: Failing run
+              if: ${{ contains(needs.*.result, 'failure') }}
+              run: exit 1


### PR DESCRIPTION
When adding GitHub protection rules for a job, one needs to select the jobs based on the name, for example here "coding standards / coding standards".

However, for jobs that are issued from a matrix, like here the unit test, one needs to add `unit tests / PHP 8.1 - Symfony 5.4.* - Composer --prefer-stable`, `unit tests / PHP 8.2 - Symfony 5.4.* - Composer --prefer-stable` and co. manually. This is both tedious to add and to keep up to date as any change in the matrix result in this rule to be outdated.

This PR introduces a very simple solution: have a meta job that passes if and only if all of the unit tests passes. This way we can have a rule for this job instead, which has a fixed label.