### PR TITLE
ci: Update actions/checkout version

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: "ubuntu-latest"
         steps:
             - name: "checkout"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
 
             - name: "build the environment"
               run: "dev/bin/docker-compose build"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: "ubuntu-latest"
         steps:
             - name: "checkout"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
 
             - name: "build the environment"
               run: "dev/bin/docker-compose build"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
         steps:
             - name: "checkout"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
 
             - name: "build the PHP7 environment"
               run: "dev/bin/docker-compose build --build-arg PHP_VERSION=${{ matrix.php }} php"


### PR DESCRIPTION
This allows to get rid of the following deprecations:

```
PHP 7.2 - Symfony 5.4.* - Composer --prefer-stable --prefer-lowest
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.
```