### PR TITLE
Support Doctrine ORM 3.0

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,12 @@ jobs:
     static-analysis:
         name: "static analysis"
         runs-on: "ubuntu-latest"
+        strategy:
+            fail-fast: false
+            matrix:
+                doctrine-orm: ['2.14.*', '2.18.*', '3.0.*']
+                composer-flags: ['--prefer-stable']
+
         steps:
             - name: "checkout"
               uses: "actions/checkout@v4"
@@ -18,8 +24,11 @@ jobs:
             - name: "build the environment"
               run: "dev/bin/docker-compose build"
 
+            - name: "require specific Doctrine ORM version"
+              run: "dev/bin/php composer require --ansi ${{ matrix.composer-flags }} doctrine/orm:${{ matrix.doctrine-orm }}"
+
             - name: "install dependencies"
-              run: "dev/bin/php composer update --prefer-stable"
+              run: "dev/bin/php composer update --ansi ${{ matrix.composer-flags }}"
 
             - name: "run static analysis"
               run: "dev/bin/php psalm --shepherd --stats"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,13 +16,18 @@ jobs:
             matrix:
                 php: ['8.1', '8.2', '8.3']
                 symfony: ['5.4.*', '6.4.*', '7.0.*']
+                doctrine-orm: ['2.14.*', '2.18.*', '3.0.*']
                 composer-flags: ['--prefer-stable']
                 can-fail: [false]
                 exclude:
                     - php: "8.1"
                       symfony: "7.0.*"
+                    - doctrine-orm: "2.14.*"
+                      symfony: "6.4.*"
+                    - doctrine-orm: "2.14.*"
+                      symfony: "7.0.*"
 
-        name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
+        name: "PHP ${{ matrix.php }} - Doctrine ${{ matrix.doctrine-orm }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
 
         env:
             SYMFONY_REQUIRE: ${{ matrix.symfony }}
@@ -33,6 +38,9 @@ jobs:
 
             - name: "build the PHP environment"
               run: "dev/bin/docker-compose build --build-arg PHP_VERSION=${{ matrix.php }} --build-arg XDEBUG_VERSION='3.3.1' php"
+
+            - name: "require specific Doctrine ORM version"
+              run: "dev/bin/php composer require --ansi ${{ matrix.composer-flags }} doctrine/orm:${{ matrix.doctrine-orm }}"
 
             - name: "install dependencies"
               run: "dev/bin/php composer update --ansi ${{ matrix.composer-flags }}"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "doctrine/doctrine-bundle": "^2.0.8",
-        "doctrine/orm": "^2.7.1",
+        "doctrine/orm": "^2.14|^3.0",
         "league/oauth2-server": "^8.3",
         "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",

--- a/src/Model/AbstractClient.php
+++ b/src/Model/AbstractClient.php
@@ -15,45 +15,21 @@ use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
  */
 abstract class AbstractClient implements ClientInterface
 {
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
+    protected string $identifier;
+    private ?string $secret;
 
-    /**
-     * @var string
-     */
-    protected $identifier;
+    /** @var list<RedirectUri> */
+    private array $redirectUris = [];
 
-    /**
-     * @var string|null
-     */
-    private $secret;
+    /** @var list<Grant> */
+    private array $grants = [];
 
-    /**
-     * @var list<RedirectUri>
-     */
-    private $redirectUris = [];
+    /** @var list<Scope> */
+    private array $scopes = [];
 
-    /**
-     * @var list<Grant>
-     */
-    private $grants = [];
-
-    /**
-     * @var list<Scope>
-     */
-    private $scopes = [];
-
-    /**
-     * @var bool
-     */
-    private $active = true;
-
-    /**
-     * @var bool
-     */
-    private $allowPlainTextPkce = false;
+    private bool $active = true;
+    private bool $allowPlainTextPkce = false;
 
     /**
      * @psalm-mutation-free
@@ -165,7 +141,7 @@ abstract class AbstractClient implements ClientInterface
      */
     public function isConfidential(): bool
     {
-        return !empty($this->secret);
+        return null !== $this->secret && '' !== $this->secret;
     }
 
     /**

--- a/src/Model/RefreshToken.php
+++ b/src/Model/RefreshToken.php
@@ -6,30 +6,15 @@ namespace League\Bundle\OAuth2ServerBundle\Model;
 
 class RefreshToken implements RefreshTokenInterface
 {
-    /**
-     * @var string
-     */
-    private $identifier;
-
-    /**
-     * @var \DateTimeInterface
-     */
-    private $expiry;
-
-    /**
-     * @var AccessTokenInterface|null
-     */
-    private $accessToken;
-
-    /**
-     * @var bool
-     */
-    private $revoked = false;
+    private string $identifier;
+    private \DateTimeInterface $expiry;
+    private ?AccessTokenInterface $accessToken;
+    private bool $revoked = false;
 
     /**
      * @psalm-mutation-free
      */
-    public function __construct(string $identifier, \DateTimeInterface $expiry, AccessTokenInterface $accessToken = null)
+    public function __construct(string $identifier, \DateTimeInterface $expiry, ?AccessTokenInterface $accessToken = null)
     {
         $this->identifier = $identifier;
         $this->expiry = $expiry;

--- a/src/Security/Authenticator/OAuth2Authenticator.php
+++ b/src/Security/Authenticator/OAuth2Authenticator.php
@@ -36,25 +36,10 @@ final class OAuth2Authenticator implements AuthenticatorInterface, Authenticatio
      */
     use ForwardCompatAuthenticatorTrait;
 
-    /**
-     * @var HttpMessageFactoryInterface
-     */
-    private $httpMessageFactory;
-
-    /**
-     * @var ResourceServer
-     */
-    private $resourceServer;
-
-    /**
-     * @var UserProviderInterface
-     */
-    private $userProvider;
-
-    /**
-     * @var string
-     */
-    private $rolePrefix;
+    private HttpMessageFactoryInterface $httpMessageFactory;
+    private ResourceServer $resourceServer;
+    private UserProviderInterface $userProvider;
+    private string $rolePrefix;
 
     public function __construct(
         HttpMessageFactoryInterface $httpMessageFactory,
@@ -73,7 +58,7 @@ final class OAuth2Authenticator implements AuthenticatorInterface, Authenticatio
         return str_starts_with($request->headers->get('Authorization', ''), 'Bearer ');
     }
 
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         return new Response('', 401, ['WWW-Authenticate' => 'Bearer']);
     }

--- a/src/Security/Exception/InsufficientScopesException.php
+++ b/src/Security/Exception/InsufficientScopesException.php
@@ -9,7 +9,7 @@ namespace League\Bundle\OAuth2ServerBundle\Security\Exception;
  */
 class InsufficientScopesException extends OAuth2AuthenticationException
 {
-    public static function create(\Throwable $previous = null): self
+    public static function create(?\Throwable $previous = null): self
     {
         return new self('Insufficient scopes.', 403, $previous);
     }

--- a/src/Security/Exception/OAuth2AuthenticationException.php
+++ b/src/Security/Exception/OAuth2AuthenticationException.php
@@ -12,12 +12,9 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 class OAuth2AuthenticationException extends AuthenticationException implements HttpExceptionInterface
 {
-    /**
-     * @var int
-     */
-    private $statusCode;
+    private int $statusCode;
 
-    public function __construct(string $message, int $statusCode, \Throwable $previous = null)
+    public function __construct(string $message, int $statusCode, ?\Throwable $previous = null)
     {
         $this->statusCode = $statusCode;
 

--- a/src/Security/Exception/OAuth2AuthenticationFailedException.php
+++ b/src/Security/Exception/OAuth2AuthenticationFailedException.php
@@ -9,7 +9,7 @@ namespace League\Bundle\OAuth2ServerBundle\Security\Exception;
  */
 class OAuth2AuthenticationFailedException extends OAuth2AuthenticationException
 {
-    public static function create(string $message, \Throwable $previous = null): self
+    public static function create(string $message, ?\Throwable $previous = null): self
     {
         return new self($message, 401, $previous);
     }

--- a/tests/Acceptance/DoctrineCredentialsRevokerTest.php
+++ b/tests/Acceptance/DoctrineCredentialsRevokerTest.php
@@ -90,7 +90,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
         );
     }
 
-    private function buildAccessToken(string $identifier, string $modify, Client $client, string $userIdentifier = null): AccessToken
+    private function buildAccessToken(string $identifier, string $modify, Client $client, ?string $userIdentifier = null): AccessToken
     {
         return new AccessToken(
             $identifier,
@@ -101,7 +101,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
         );
     }
 
-    private function buildAuthCode(string $identifier, string $modify, Client $client, string $userIdentifier = null): AuthorizationCode
+    private function buildAuthCode(string $identifier, string $modify, Client $client, ?string $userIdentifier = null): AuthorizationCode
     {
         return new AuthorizationCode(
             $identifier,


### PR DESCRIPTION
Doctrine ORM v3.0.0 has been released.
https://github.com/doctrine/orm/releases/tag/3.0.0

Upgrade the minimal version of the ORM to v2.14, allow v3.0 as well. This matches the version requirement as used by [doctrine/doctrine-fixtures-bundle](https://github.com/doctrine/DoctrineFixturesBundle/blob/6c3253bfd071b57fac9a5b02cd7b1e5b9803148e/composer.json#L26).

Update the GitHub workflows to test against v2.14, v2.18 and v3.0.