### PR TITLE
basic-setup.md: Add create-client's name arg

### DIFF
--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -13,7 +13,7 @@ Description:
   Creates a new oAuth2 client
 
 Usage:
-  league:oauth2-server:create-client [options] [--] [<identifier> [<secret>]]
+  league:oauth2-server:create-client [options] [--] <name> [<identifier> [<secret>]]
 
 Arguments:
   name                               The client name


### PR DESCRIPTION
`name` is the first argument and is mandatory.

See
- `php bin/console help league:oauth2-server:create-client`
- [`CreateClientCommand::configure`](https://github.com/thephpleague/oauth2-server-bundle/blob/master/src/Command/CreateClientCommand.php#L79-L93)