### PR TITLE
Fix client credentials overriding `getSubjectIdentifier`

### DIFF
--- a/src/Entity/AccessToken.php
+++ b/src/Entity/AccessToken.php
@@ -14,4 +14,9 @@ final class AccessToken implements AccessTokenEntityInterface
     use AccessTokenTrait;
     use EntityTrait;
     use TokenEntityTrait;
+
+    public function getSubjectIdentifier(): string
+    {
+        return $this->userIdentifier ?? '';
+    }
 }

--- a/tests/Integration/ResourceServerTest.php
+++ b/tests/Integration/ResourceServerTest.php
@@ -95,4 +95,20 @@ final class ResourceServerTest extends AbstractIntegrationTest
 
         $this->assertNull($request);
     }
+
+    public function testValidClientCredentialsGrant(): void
+    {
+        $tokenResponse = $this->handleTokenRequest(
+            $this->createAuthorizationRequest(null, [
+                'client_id' => 'foo',
+                'client_secret' => 'secret',
+                'grant_type' => 'client_credentials',
+            ])
+        );
+
+        $resourceRequest = $this->handleResourceRequest($this->createResourceRequest($tokenResponse['access_token']));
+        $this->assertSame(FixtureFactory::FIXTURE_CLIENT_FIRST, $resourceRequest->getAttribute('oauth_client_id'));
+        $this->assertSame('', $resourceRequest->getAttribute('oauth_user_id'));
+        $this->assertSame([], $resourceRequest->getAttribute('oauth_scopes'));
+    }
 }


### PR DESCRIPTION
In `league/server-bundle` version `0.8`, when the client_credentials
grant is used, the `sub` claim of the JWT is an empty string, but in
version `0.9` is filled with the client ID.

We override the `getSubjectIdentifier` of the AccessToken entity to
return an empty string again when the client_credentials grant is used.

Fix #207 