### PR TITLE
feat: allow configuring revocation of refresh tokens

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,9 @@ For implementation into Symfony projects, please see [bundle documentation](basi
             # Whether to enable access token saving to persistence layer (default to true)
             persist_access_token: true
 
+            # Whether to revoke refresh tokens after they were used for all grant types (default to true)
+            revoke_refresh_tokens: true
+
         resource_server:      # Required
 
             # Full path to the public key file

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -111,6 +111,10 @@ final class Configuration implements ConfigurationInterface
                     ->info('Define a custom ResponseType')
                     ->defaultValue(null)
                 ->end()
+                ->booleanNode('revoke_refresh_tokens')
+                    ->info('Whether to revoke refresh tokens after they were used for all grant types')
+                    ->defaultTrue()
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -148,6 +148,10 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
             $authorizationServer->replaceArgument(5, new Reference($config['response_type_class']));
         }
 
+        $authorizationServer->addMethodCall('revokeRefreshTokens', [
+            $config['revoke_refresh_tokens'],
+        ]);
+
         if ($config['enable_client_credentials_grant']) {
             $authorizationServer->addMethodCall('enableGrantType', [
                 new Reference(ClientCredentialsGrant::class),


### PR DESCRIPTION
adds a configuration for disabling revocation of refresh token after they were used. this configuration applies to all grant types that will be enabled.

complies with `league/oauth2-server`: https://github.com/thephpleague/oauth2-server/blob/master/src/AuthorizationServer.php#L209-L215

```
# config/packages/league_oauth2_server.yaml

league_oauth2_server:
    authorization_server:
        revoke_refresh_tokens: false
```