### PR TITLE
feat: Add jwt leeway configuration option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,9 @@ For implementation into Symfony projects, please see [bundle documentation](basi
             # How to generate a public key: https://oauth2.thephpleague.com/installation/#generating-public-and-private-keys
             public_key:           ~ # Required, Example: /var/oauth/public.key
 
+            # The leeway in seconds to allow for clock skew in JWT verification. Default PT0S (no leeway).
+            jwt_leeway: null
+
         scopes:
             # Scopes that you wish to utilize in your application.
             # This should be a simple array of strings.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -131,6 +131,11 @@ final class Configuration implements ConfigurationInterface
                     ->isRequired()
                     ->cannotBeEmpty()
                 ->end()
+                ->scalarNode('jwt_leeway')
+                    ->info('The leeway in seconds to allow for clock skew in JWT verification. Default PT0S (no leeway).')
+                    ->example('PT60S')
+                    ->defaultValue(null)
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -27,6 +27,7 @@ use League\Bundle\OAuth2ServerBundle\Service\CredentialsRevoker\DoctrineCredenti
 use League\Bundle\OAuth2ServerBundle\Service\CredentialsRevokerInterface;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope as ScopeModel;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -331,6 +332,11 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
                 false,
             ]))
         ;
+        if (null !== $config['jwt_leeway']) {
+            $container
+                ->findDefinition(BearerTokenValidator::class)
+                ->replaceArgument(1, new Definition(\DateInterval::class, [$config['jwt_leeway']]));
+        }
     }
 
     private function configureScopes(ContainerBuilder $container, array $scopes): void

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -38,6 +38,7 @@ use League\Bundle\OAuth2ServerBundle\Security\Authenticator\OAuth2Authenticator;
 use League\Bundle\OAuth2ServerBundle\Security\EventListener\CheckScopeListener;
 use League\Bundle\OAuth2ServerBundle\Service\SymfonyLeagueEventListenerProvider;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
 use League\OAuth2\Server\EventEmitting\EventEmitter;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -153,11 +154,20 @@ return static function (ContainerConfigurator $container): void {
             ->configurator(service(GrantConfigurator::class))
         ->alias(AuthorizationServer::class, 'league.oauth2_server.authorization_server')
 
+        // League bearer token validator
+        ->set('league.oauth2_server.bearer_token_validator', BearerTokenValidator::class)
+            ->args([
+                service(AccessTokenRepositoryInterface::class),
+                null,
+            ])
+        ->alias(BearerTokenValidator::class, 'league.oauth2_server.bearer_token_validator')
+
         // League resource server
         ->set('league.oauth2_server.resource_server', ResourceServer::class)
             ->args([
                 service(AccessTokenRepositoryInterface::class),
                 null,
+                service(BearerTokenValidator::class),
             ])
         ->alias(ResourceServer::class, 'league.oauth2_server.resource_server')
 

--- a/tests/Acceptance/CustomPersistenceManagerTest.php
+++ b/tests/Acceptance/CustomPersistenceManagerTest.php
@@ -159,6 +159,7 @@ class CustomPersistenceManagerTest extends AbstractAcceptanceTest
         return new TestKernel(
             'test',
             false,
+            null,
             [
                 'custom' => [
                     'access_token_manager' => 'test.access_token_manager',

--- a/tests/Acceptance/JwtLeewayConfigurationTest.php
+++ b/tests/Acceptance/JwtLeewayConfigurationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Bundle\OAuth2ServerBundle\Tests\Acceptance;
+
+use League\Bundle\OAuth2ServerBundle\Repository\AccessTokenRepository;
+use League\Bundle\OAuth2ServerBundle\Tests\TestKernel;
+use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class JwtLeewayConfigurationTest extends AbstractAcceptanceTest
+{
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->application = new Application($this->client->getKernel());
+    }
+
+    public function testLeewayConfigurationIsSet(): void
+    {
+        /** @var AccessTokenRepository $tokenRepository */
+        $tokenRepository = $this->client->getContainer()->get(AccessTokenRepository::class);
+        $validator = $this->client->getContainer()->get(BearerTokenValidator::class);
+
+        $expected = new BearerTokenValidator($tokenRepository, new \DateInterval('PT60S'));
+        $this->assertEquals($expected, $validator);
+    }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new TestKernel(
+            'test',
+            false,
+            [
+                'public_key' => '%env(PUBLIC_KEY_PATH)%',
+                'jwt_leeway' => 'PT60S',
+            ]
+        );
+    }
+}

--- a/tests/Integration/AuthorizationServerTest.php
+++ b/tests/Integration/AuthorizationServerTest.php
@@ -700,8 +700,8 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
         $response = $this->handleTokenRequest($request);
 
         // Response assertions.
-        $this->assertSame('invalid_client', $response['error']);
-        $this->assertSame('Client authentication failed', $response['error_description']);
+        $this->assertSame('invalid_request', $response['error']);
+        $this->assertSame('The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.', $response['error_description']);
     }
 
     public function testSuccessfulImplicitRequest(): void


### PR DESCRIPTION
When a jwt token is created on one server and then used on another, there might be a slight time difference in the jwt token timestamp. However the jwt validation is by default set to `PT0S` leeway and rejects the jwt token.

The league/oauth2-server uses lcobucci/jwt for jwt creation and validation. There's an option to set the jwt leeway. See
the constructor of https://github.com/thephpleague/oauth2-server/blob/master/src/AuthorizationValidators/BearerTokenValidator.php

However there is no way to set this value via the oauth2-server-bundle. This PR allows to set this value.