### PR TITLE
Require `league/oauth2-server:^9.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-openssl": "*",
         "doctrine/doctrine-bundle": "^2.8.0",
         "doctrine/orm": "^2.14|^3.0",
-        "league/oauth2-server": "^9.1",
+        "league/oauth2-server": "^9.2",
         "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",
         "symfony/event-dispatcher": "^5.4|^6.2|^7.0",


### PR DESCRIPTION
It fixes tests with lowest allowed versions