### PR TITLE
test: Fix incorrect class name

### DIFF
--- a/tests/Acceptance/AbstractAcceptanceTest.php
+++ b/tests/Acceptance/AbstractAcceptanceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Tests\Acceptance;
 
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use League\Bundle\OAuth2ServerBundle\Tests\TestHelper;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -31,7 +31,7 @@ abstract class AbstractAcceptanceTest extends WebTestCase
         TestHelper::initializeDoctrineSchema($this->application);
 
         $connection = $this->client->getContainer()->get('database_connection');
-        if ($connection->getDatabasePlatform() instanceof SqlitePlatform) {
+        if ($connection->getDatabasePlatform() instanceof SQLitePlatform) {
             // https://www.sqlite.org/foreignkeys.html
             $connection->executeQuery('PRAGMA foreign_keys = ON');
         }

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace League\Bundle\OAuth2ServerBundle\Tests;
 
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Mapping\Annotation;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AuthorizationCodeManagerInterface;
@@ -229,7 +229,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
     private function configureDatabaseServices(ContainerBuilder $container): void
     {
         $container
-            ->register(SqlitePlatform::class)
+            ->register(SQLitePlatform::class)
             ->setAutoconfigured(true)
             ->setAutowired(true)
         ;


### PR DESCRIPTION
Fixes the following error:

```
1) League\Bundle\OAuth2ServerBundle\Tests\Acceptance\AuthorizationEndpointTest::testSuccessfulCodeRequest
RuntimeException: Case mismatch between loaded and declared class names: "Doctrine\DBAL\Platforms\SqlitePlatform" vs "Doctrine\DBAL\Platforms\SQLitePlatform".

/path/to/oauth2-server-bundle/vendor/symfony/error-handler/DebugClassLoader.php:339
```