### PR TITLE
Remove polyfill requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/filesystem": "^6.4|^7.0",
         "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/polyfill-php81": "^1.22",
         "symfony/psr-http-message-bridge": "^6.4|^7",
         "symfony/security-bundle": "^6.4|^7.0"
     },


### PR DESCRIPTION
The bundle requires php:^8.1 so this polyfill is useless.