### PR TITLE
[RFC] Move doctrine packages to suggest section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Replacement of trikoder/oauth2-bundle made in coordination with [trikoder](https
     composer require league/oauth2-server-bundle
     ```
 
+2. Require Doctrine to use it as persistence layer:
+
+    ```sh
+    composer require doctrine/doctrine-bundle doctrine/orm
+    ```
+
 ## Documentation
 
 The docs [can be found in the `docs/` directory](docs/index.md) of this repository.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
     "require": {
         "php": "^8.1",
         "ext-openssl": "*",
-        "doctrine/doctrine-bundle": "^2.8.0",
-        "doctrine/orm": "^2.14|^3.0",
         "league/oauth2-server": "^9.2",
         "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",
@@ -34,8 +32,18 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
+        "doctrine/doctrine-bundle": "^2.8.0",
+        "doctrine/orm": "^2.14|^3.0",
         "symfony/browser-kit": "^6.4|^7.0",
         "symfony/phpunit-bridge": "^7.2"
+    },
+    "conflict": {
+        "doctrine/doctrine-bundle": "<2.8.0",
+        "doctrine/orm": "<2.14"
+    },
+    "suggest": {
+        "doctrine/doctrine-bundle": "Allow usage of doctrine as persistence layer",
+        "doctrine/orm": "Allow usage of doctrine as persistence layer"
     },
     "autoload": {
         "psr-4": { "League\\Bundle\\OAuth2ServerBundle\\": "src/" }


### PR DESCRIPTION
I think we can move doctrine packages to suggest section.

What do you think? Should we edit the bundle recipe to use `in_memory` as persistence layer?