### PR TITLE
Deprecate eraseCredentials (symfony 7.3 compatibility)

### DIFF
--- a/src/Security/User/ClientCredentialsUser.php
+++ b/src/Security/User/ClientCredentialsUser.php
@@ -34,6 +34,7 @@ final class ClientCredentialsUser implements UserInterface
         return [];
     }
 
+    #[\Deprecated]
     public function eraseCredentials(): void
     {
         return;


### PR DESCRIPTION
Since symfony/security-http 7.3: Implementing "eraseCredentials()" is deprecated

https://symfony.com/blog/new-in-symfony-7-3-security-improvements#deprecate-erasecredentials-method