### PR TITLE
fix(docs): code block typo

### DIFF
--- a/docs/using-custom-persistence-managers.md
+++ b/docs/using-custom-persistence-managers.md
@@ -8,9 +8,7 @@ Implement the 4 interfaces from the `League\Bundle\OAuth2ServerBundle\Manager` n
 And the interface for `CredentialsRevokerInterface`:
 - [CredentialsRevokerInterface](../src/Service/CredentialsRevokerInterface.php)
 
-```php
-
-Example:
+## Example:
 
 ```php
 class MyAccessTokenManager implements AccessTokenManagerInterface


### PR DESCRIPTION
This pull request updates the documentation to improve clarity and formatting for implementing custom persistence managers. The most notable change is the addition of a proper heading for the example code section in the `docs/using-custom-persistence-managers.md` file.

Documentation improvements:

* [`docs/using-custom-persistence-managers.md`](diffhunk://#diff-53a538209b19a41d82bb0a11680b09aaa7a6aa7ab1ad63f239b1c762235d8dd9L11-R11): Replaced a misplaced "Example:" label with a proper Markdown heading (`## Example:`) to enhance readability and consistency in the documentation.