### PR TITLE
fix: Test for availability of doctrine in bundle configuration

### DIFF
--- a/src/LeagueOAuth2ServerBundle.php
+++ b/src/LeagueOAuth2ServerBundle.php
@@ -43,14 +43,16 @@ final class LeagueOAuth2ServerBundle extends Bundle
 
     private function configureDoctrineExtension(ContainerBuilder $container): void
     {
-        $container->addCompilerPass(
-            new DoctrineOrmMappingsPass(
-                new Reference(Driver::class),
-                ['League\Bundle\OAuth2ServerBundle\Model'],
-                ['league.oauth2_server.persistence.doctrine.manager'],
-                'league.oauth2_server.persistence.doctrine.enabled'
-            )
-        );
+        if (ContainerBuilder::willBeAvailable('doctrine/doctrine-bundle', DoctrineOrmMappingsPass::class, ['league/oauth2-server-bundle'])) {
+            $container->addCompilerPass(
+                new DoctrineOrmMappingsPass(
+                    new Reference(Driver::class),
+                    ['League\Bundle\OAuth2ServerBundle\Model'],
+                    ['league.oauth2_server.persistence.doctrine.manager'],
+                    'league.oauth2_server.persistence.doctrine.enabled'
+                )
+            );
+        }
 
         $container->addCompilerPass(new EncryptionKeyPass());
     }


### PR DESCRIPTION
As doctrine is now a composer suggestion instead of requirement, added `class_exists` check when configuring doctrine in the bundle. If it's absent, do not configure the `DoctrineOrmMappingsPass`