### PR TITLE
Unlink cleaned up access tokens from refresh tokens

### DIFF
--- a/tests/Acceptance/DoctrineAccessTokenManagerTest.php
+++ b/tests/Acceptance/DoctrineAccessTokenManagerTest.php
@@ -123,10 +123,9 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
 
         $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
 
-        $this->assertSame(
-            $testData['output'],
-            $em->getRepository(RefreshToken::class)->findBy(['accessToken' => null], ['identifier' => 'ASC'])
-        );
+        $em->clear();
+
+        self::assertCount(3, $em->getRepository(RefreshToken::class)->findBy(['accessToken' => null], ['identifier' => 'ASC']));
     }
 
     public function testClearExpiredWithRefreshTokenWithoutSavingAccessToken(): void

--- a/tests/Acceptance/DoctrineClientManagerTest.php
+++ b/tests/Acceptance/DoctrineClientManagerTest.php
@@ -22,7 +22,7 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
 {
     public function testSimpleDelete(): void
     {
-        /** @var $em EntityManagerInterface */
+        /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
         $doctrineClientManager = new DoctrineClientManager($em, self::getContainer()->get(EventDispatcherInterface::class), Client::class);
 
@@ -41,7 +41,7 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
 
     public function testClientDeleteCascadesToAccessTokens(): void
     {
-        /** @var $em EntityManagerInterface */
+        /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
         $doctrineClientManager = new DoctrineClientManager($em, self::getContainer()->get(EventDispatcherInterface::class), Client::class);
 
@@ -74,7 +74,7 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
 
     public function testSaveClientWithoutScopeAddDefaultScopes(): void
     {
-        /** @var $em EntityManagerInterface */
+        /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
         $doctrineClientManager = new DoctrineClientManager($em, self::getContainer()->get(EventDispatcherInterface::class), Client::class);
 
@@ -88,7 +88,7 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
 
     public function testClientDeleteCascadesToAccessTokensAndRefreshTokens(): void
     {
-        /** @var $em EntityManagerInterface */
+        /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
         $doctrineClientManager = new DoctrineClientManager($em, self::getContainer()->get(EventDispatcherInterface::class), Client::class);
 
@@ -122,7 +122,7 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
                 ->find($accessToken->getIdentifier())
         );
 
-        /** @var $refreshToken RefreshToken */
+        /** @var RefreshToken $refreshToken */
         $refreshToken = $em
             ->getRepository(RefreshToken::class)
             ->find($refreshToken->getIdentifier())


### PR DESCRIPTION
Fixes issue: #247
Breaking changes: no
 
Changes `AccessTokenManager::clearExpiredTokens` to:
- Find all access token identifiers that have expired.
- Execute query to unlink these identifiers from possible refresh tokens.
- Thirdly delete the access tokens with those ids.

This order ensures that at no point in time there's a refresh token with an invalid access token reference.


## Testing
There was already an existing unit test testing the above scenario but didn't trigger the issue because the entity manager wasn't cleared (and the test ran against the EntityManager memory instead of the database). As soon as I added the `$em->clear()` to the test the scenario above occurred. As the original object compare doesn't work anymore as the refresh tokens are actually retrieved from the db instead of the entity manager memory, the DateTime values and object references differ. The test now should find all unlinked refresh tokens. 

## Technical choices
Looking at the relation between RefreshToken and AccessToken, the relation is defined as `SET TO NULL` when the access token is deleted. However as the access tokens aren't deleted through the EntityManager this `SET TO NULL` is never triggered. An alternative implementation would be to retrieve all the expired AccessTokens and delete them through the EntityManager. However I think performance wise this will not be quick.