### PR TITLE
Allow testing against `doctrine/doctrine-bundle:^3.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
-        "doctrine/doctrine-bundle": "^2.8.0",
+        "doctrine/doctrine-bundle": "^2.8|^3.0",
         "doctrine/orm": "^2.14|^3.0",
         "symfony/browser-kit": "^6.4|^7.0",
         "symfony/phpunit-bridge": "^7.2"

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace League\Bundle\OAuth2ServerBundle\Tests;
 
 use Doctrine\DBAL\Platforms\SQLitePlatform;
-use Doctrine\ORM\Mapping\Annotation;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\AuthorizationCodeManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
@@ -90,8 +89,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                 ],
             ];
 
-            $doctrine['orm'] = ['enable_lazy_ghost_objects' => !interface_exists(Annotation::class)];
-
+            $doctrine['orm'] = [];
             $container->loadFromExtension('doctrine', $doctrine);
 
             $framework = [


### PR DESCRIPTION
First step toward Symfony 8 support