### PR TITLE
Fix redirection URLs when implicit grant is denied

### DIFF
--- a/src/Controller/AuthorizationController.php
+++ b/src/Controller/AuthorizationController.php
@@ -111,7 +111,7 @@ final class AuthorizationController
 
             $response = $this->server->completeAuthorizationRequest($authRequest, $serverResponse);
         } catch (OAuthServerException $e) {
-            $response = $e->generateHttpResponse($serverResponse);
+            $response = $e->generateHttpResponse($serverResponse, str_contains($e->getRedirectUri() ?? '', '#'));
         }
 
         return $this->httpFoundationFactory->createResponse($response);


### PR DESCRIPTION
It was generating URLs mixing fragment and query string.