### PR TITLE
enable_authenticator_manager is deprecated

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -128,13 +128,6 @@ For implementation into Symfony projects, please see [bundle documentation](basi
     bin/console doctrine:schema:update --force
     ```
 
-1. Enable the authenticator security system in `config/security.yaml` file:
-
-```yaml
-security:
-    enable_authenticator_manager: true
-```
-
 1. Import the routes inside your `config/routes.yaml` file:
 
     ```yaml


### PR DESCRIPTION
The `enable_authenticator_manager` option is actually deprecated for several years now: https://github.com/symfony/symfony/pull/47890

And is not required anymore for Symfony 7.0 and up.. 