### PR TITLE
Allow user override on auth request resolve event

### DIFF
--- a/src/Event/AuthorizationRequestResolveEvent.php
+++ b/src/Event/AuthorizationRequestResolveEvent.php
@@ -99,6 +99,13 @@ final class AuthorizationRequestResolveEvent extends Event
         return $this->user;
     }
 
+    public function setUser(UserInterface $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
     /**
      * @return Scope[]
      */

--- a/tests/Acceptance/AuthorizationEndpointTest.php
+++ b/tests/Acceptance/AuthorizationEndpointTest.php
@@ -138,6 +138,77 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         $this->assertInstanceOf(AuthorizationCode::class, $authCode);
         $this->assertSame(FixtureFactory::FIXTURE_PUBLIC_CLIENT, $authCode->getClient()->getIdentifier());
+        $this->assertSame(FixtureFactory::FIXTURE_USER, $authCode->getUserIdentifier());
+    }
+
+    public function testSuccessfulAuthCodeRequestWhenTheLoggedUserIsOverriddenInTheAuthorizationRequestResolveEvent(): void
+    {
+        $state = bin2hex(random_bytes(20));
+        $codeVerifier = bin2hex(random_bytes(64));
+        $codeChallengeMethod = 'S256';
+
+        $codeChallenge = strtr(
+            rtrim(base64_encode(hash('sha256', $codeVerifier, true)), '='),
+            '+/',
+            '-_'
+        );
+
+        $this->loginUser();
+
+        $this->client
+            ->getContainer()
+            ->get('event_dispatcher')
+            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event) use ($state, $codeChallenge, $codeChallengeMethod): void {
+                $this->assertSame($state, $event->getState());
+                $this->assertSame($codeChallenge, $event->getCodeChallenge());
+                $this->assertSame($codeChallengeMethod, $event->getCodeChallengeMethod());
+
+                $event->setUser(FixtureFactory::createUser([], FixtureFactory::FIXTURE_USER_TWO));
+                $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
+            });
+
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => $state,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+            ]
+        );
+
+        $response = $this->client->getResponse();
+
+        $this->assertSame(302, $response->getStatusCode());
+        $redirectUri = $response->headers->get('Location');
+
+        $this->assertStringStartsWith(FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI, $redirectUri);
+        $query = [];
+        parse_str(parse_url($redirectUri, \PHP_URL_QUERY), $query);
+        $this->assertArrayHasKey('state', $query);
+        $this->assertSame($state, $query['state']);
+
+        $this->assertArrayHasKey('code', $query);
+        $payload = json_decode(TestHelper::decryptPayload($query['code']), true);
+
+        $this->assertArrayHasKey('code_challenge', $payload);
+        $this->assertArrayHasKey('code_challenge_method', $payload);
+        $this->assertSame($codeChallenge, $payload['code_challenge']);
+        $this->assertSame($codeChallengeMethod, $payload['code_challenge_method']);
+
+        /** @var AuthorizationCode|null $authCode */
+        $authCode = $this->client
+            ->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository(AuthorizationCode::class)
+            ->findOneBy(['identifier' => $payload['auth_code_id']]);
+
+        $this->assertInstanceOf(AuthorizationCode::class, $authCode);
+        $this->assertSame(FixtureFactory::FIXTURE_PUBLIC_CLIENT, $authCode->getClient()->getIdentifier());
+        $this->assertSame(FixtureFactory::FIXTURE_USER_TWO, $authCode->getUserIdentifier());
     }
 
     public function testAuthCodeRequestWithPublicClientWithoutCodeChallengeWhenTheChallengeIsRequiredForPublicClients(): void

--- a/tests/Fixtures/FixtureFactory.php
+++ b/tests/Fixtures/FixtureFactory.php
@@ -61,11 +61,12 @@ final class FixtureFactory
     public const FIXTURE_SCOPE_SECOND = 'rock';
 
     public const FIXTURE_USER = 'user';
+    public const FIXTURE_USER_TWO = 'user_two';
     public const FIXTURE_PASSWORD = 'password';
 
-    public static function createUser(array $roles = []): User
+    public static function createUser(array $roles = [], ?string $userIdentifier = null): User
     {
-        $user = new User();
+        $user = new User($userIdentifier);
         $user['roles'] = $roles;
 
         return $user;

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -8,6 +8,11 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class User extends \ArrayObject implements UserInterface
 {
+    public function __construct(private readonly ?string $userIdentifier = null)
+    {
+        parent::__construct();
+    }
+
     public function getRoles(): array
     {
         return $this['roles'] ?? [];
@@ -25,7 +30,7 @@ class User extends \ArrayObject implements UserInterface
 
     public function getUserIdentifier(): string
     {
-        return FixtureFactory::FIXTURE_USER;
+        return $this->userIdentifier ?? FixtureFactory::FIXTURE_USER;
     }
 
     public function eraseCredentials(): void

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -139,6 +139,9 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                                 FixtureFactory::FIXTURE_USER => [
                                     'roles' => ['ROLE_USER'],
                                 ],
+                                FixtureFactory::FIXTURE_USER_TWO => [
+                                    'roles' => ['ROLE_USER'],
+                                ],
                             ],
                         ],
                     ],
@@ -146,6 +149,9 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                         'memory' => [
                             'users' => [
                                 FixtureFactory::FIXTURE_USER => [
+                                    'roles' => ['ROLE_USER'],
+                                ],
+                                FixtureFactory::FIXTURE_USER_TWO => [
                                     'roles' => ['ROLE_USER'],
                                 ],
                             ],


### PR DESCRIPTION
The ability to override the user on the `AuthorizationRequestResolveEvent` event was removed in https://github.com/thephpleague/oauth2-server-bundle/pull/196 without any reason IMO.

We are using this for admin impersonation purposes. We are trying to update from v0.8 to v1 but this is blocking us from doing so.
So I'm sending this pull request so that overriding the user becomes possible again.