### PR TITLE
Update the cron schedule for GitHub workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,7 +5,7 @@ on:
     push: ~
     schedule:
         # Do not make it the first of the month and/or midnight since it is a very busy time
-        - cron: "* 10 5 * *"
+        - cron: "15 10 5 * *" # Runs at 10:15, on day 5 of the month
 
 jobs:
     coding-standards:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,7 +5,7 @@ on:
     push: ~
     schedule:
         # Do not make it the first of the month and/or midnight since it is a very busy time
-        - cron: "* 10 5 * *"
+        - cron: "15 10 5 * *" # Runs at 10:15, on day 5 of the month
 
 jobs:
     static-analysis:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,7 @@ on:
     push: ~
     schedule:
         # Do not make it the first of the month and/or midnight since it is a very busy time
-        - cron: "* 10 5 * *"
+        - cron: "15 10 5 * *" # Runs at 10:15, on day 5 of the month
 
 jobs:
     tests:


### PR DESCRIPTION
The current cron expression, `* 10 5 * *` tries to run every minute between 10:00 and 10:59 on the 5th day of the month. However, action schedules run at most every five minutes. 

I've modified the cron expression to run workflows at 10:15 on the 5th of every month, which aligns with the original intent of commit e9e221d52be18ea1dc6a2d4865c07f03c4e4d325 for monthly execution.