### PR TITLE
Modify the test for doctrine bundle availability

### DIFF
--- a/src/LeagueOAuth2ServerBundle.php
+++ b/src/LeagueOAuth2ServerBundle.php
@@ -42,15 +42,18 @@ final class LeagueOAuth2ServerBundle extends Bundle
 
     private function configureDoctrineExtension(ContainerBuilder $container): void
     {
-        if (ContainerBuilder::willBeAvailable('doctrine/doctrine-bundle', DoctrineOrmMappingsPass::class, ['league/oauth2-server-bundle'])) {
-            $container->addCompilerPass(
-                new DoctrineOrmMappingsPass(
-                    new Reference(Driver::class),
-                    ['League\Bundle\OAuth2ServerBundle\Model'],
-                    ['league.oauth2_server.persistence.doctrine.manager'],
-                    'league.oauth2_server.persistence.doctrine.enabled'
-                )
-            );
+        if (!class_exists(DoctrineOrmMappingsPass::class)) {
+            return;
+        }
+
+        $container->addCompilerPass(
+            new DoctrineOrmMappingsPass(
+                new Reference(Driver::class),
+                ['League\Bundle\OAuth2ServerBundle\Model'],
+                ['league.oauth2_server.persistence.doctrine.manager'],
+                'league.oauth2_server.persistence.doctrine.enabled'
+            )
+        );
     }
 
     public function getPath(): string

--- a/src/LeagueOAuth2ServerBundle.php
+++ b/src/LeagueOAuth2ServerBundle.php
@@ -21,6 +21,8 @@ final class LeagueOAuth2ServerBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new EncryptionKeyPass());
+
         $this->configureDoctrineExtension($container);
         $this->configureSecurityExtension($container);
     }
@@ -49,9 +51,6 @@ final class LeagueOAuth2ServerBundle extends Bundle
                     'league.oauth2_server.persistence.doctrine.enabled'
                 )
             );
-        }
-
-        $container->addCompilerPass(new EncryptionKeyPass());
     }
 
     public function getPath(): string


### PR DESCRIPTION
The original proposal in #246 was to check the existence of the `DoctrineOrmMappingPass` class, but after my [review](https://github.com/thephpleague/oauth2-server-bundle/pull/246#pullrequestreview-3050688696), this was changed to use `ContainerBuilder::willBeAvailable`.

Using `ContainerBuilder::willBeAvailable` causes problems with no advantage (see https://github.com/thephpleague/oauth2-server-bundle/pull/246#issuecomment-3732513509 and https://github.com/thephpleague/oauth2-server-bundle/pull/246#issuecomment-3732635547) so I propose to use `class_exists` instead.

The the addition of the `EncryptionKeyPass` is moved outside of the `configureDoctrineExtension` method because is not related to Doctrine configuration.