### PR TITLE
docs: added missing `Resources` folder to `routes.php` path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -132,7 +132,7 @@ For implementation into Symfony projects, please see [bundle documentation](basi
 
     ```yaml
     oauth2:
-        resource: '@LeagueOAuth2ServerBundle/config/routes.php'
+        resource: '@LeagueOAuth2ServerBundle/Resources/config/routes.php'
         type: php
     ```
 


### PR DESCRIPTION
Got this error wile following the install guide. Fixed it by adding the `Resources`  folder in the path, as that is ware this file is actually located.

```
Unable to find file "@LeagueOAuth2ServerBundle/config/routes.php".
```

<img width="2207" height="407" alt="image" src="https://github.com/user-attachments/assets/ca5578ab-36e5-40d6-ac40-68c2bc90af31" />

Couldn't find an issue to link to, would you like me to create one?