### PR TITLE
Fix usage of virtual method `ClientInterface::getName`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "league/oauth2-server": "^9.2",
         "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",
-        "symfony/deprecation-contracts": "^3",
+        "symfony/deprecation-contracts": "^3.0",
         "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
         "symfony/filesystem": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/src/Command/ListClientsCommand.php
+++ b/src/Command/ListClientsCommand.php
@@ -120,8 +120,14 @@ final class ListClientsCommand extends Command
     private function getRows(array $clients, array $columns): array
     {
         return array_map(static function (ClientInterface $client) use ($columns): array {
+            if (!method_exists($client, 'getName')) { // @phpstan-ignore function.alreadyNarrowedType
+                trigger_deprecation('league/oauth2-server-bundle', '1.2', 'Not implementing method "getName()" in client "%s" is deprecated. This method will be required in 2.0.', $client::class);
+                $name = $client->getIdentifier();
+            } else {
+                $name = $client->getName();
+            }
             $values = [
-                'name' => $client->getName(),
+                'name' => $name,
                 'identifier' => $client->getIdentifier(),
                 'secret' => $client->getSecret(),
                 'scope' => implode(', ', $client->getScopes()),

--- a/src/Command/ListClientsCommand.php
+++ b/src/Command/ListClientsCommand.php
@@ -120,8 +120,14 @@ final class ListClientsCommand extends Command
     private function getRows(array $clients, array $columns): array
     {
         return array_map(static function (ClientInterface $client) use ($columns): array {
+            if (!method_exists($client, 'getName')) {
+                trigger_deprecation('league/oauth2-server-bundle', '1.2', 'Not implementing method "getName()" in client "%s" is deprecated. This method will be required in 2.0.', $client::class);
+                $name = $client->getIdentifier();
+            } else {
+                $name = $client->getName();
+            }
             $values = [
-                'name' => $client->getName(),
+                'name' => $name,
                 'identifier' => $client->getIdentifier(),
                 'secret' => $client->getSecret(),
                 'scope' => implode(', ', $client->getScopes()),

--- a/src/Model/ClientInterface.php
+++ b/src/Model/ClientInterface.php
@@ -18,6 +18,8 @@ interface ClientInterface
      */
     public function getIdentifier(): string;
 
+    // public function getName(): string;
+
     public function getSecret(): ?string;
 
     /**

--- a/src/Repository/ClientRepository.php
+++ b/src/Repository/ClientRepository.php
@@ -59,7 +59,12 @@ final class ClientRepository implements ClientRepositoryInterface
     private function buildClientEntity(ClientInterface $client): ClientEntity
     {
         $clientEntity = new ClientEntity();
-        $clientEntity->setName($client->getName());
+        if (!method_exists($client, 'getName')) { // @phpstan-ignore function.alreadyNarrowedType
+            trigger_deprecation('league/oauth2-server-bundle', '1.2', 'Not implementing method "getName()" in client "%s" is deprecated. This method will be required in 2.0.', $client::class);
+            $clientEntity->setName($client->getIdentifier());
+        } else {
+            $clientEntity->setName($client->getName());
+        }
         $clientEntity->setIdentifier($client->getIdentifier());
         $clientEntity->setRedirectUri(array_map('strval', $client->getRedirectUris()));
         $clientEntity->setConfidential($client->isConfidential());

--- a/src/Repository/ClientRepository.php
+++ b/src/Repository/ClientRepository.php
@@ -59,7 +59,12 @@ final class ClientRepository implements ClientRepositoryInterface
     private function buildClientEntity(ClientInterface $client): ClientEntity
     {
         $clientEntity = new ClientEntity();
-        $clientEntity->setName($client->getName());
+        if (!method_exists($client, 'getName')) {
+            trigger_deprecation('league/oauth2-server-bundle', '1.2', 'Not implementing method "getName()" in client "%s" is deprecated. This method will be required in 2.0.', $client::class);
+            $clientEntity->setName($client->getIdentifier());
+        } else {
+            $clientEntity->setName($client->getName());
+        }
         $clientEntity->setIdentifier($client->getIdentifier());
         $clientEntity->setRedirectUri(array_map('strval', $client->getRedirectUris()));
         $clientEntity->setConfidential($client->isConfidential());


### PR DESCRIPTION
Ensure the method exists before calling it and trigger a deprecation notice if it does not.