### PR TITLE
Fix grant restriction for public clients on League OAuth2 Server v9 

### DIFF
--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -18,6 +18,11 @@ final class Client implements ClientEntityInterface
      */
     private $allowPlainTextPkce = false;
 
+    /**
+     * @var list<non-empty-string>
+     */
+    private array $allowedGrantTypes = [];
+
     public function setName(string $name): void
     {
         $this->name = $name;
@@ -44,5 +49,26 @@ final class Client implements ClientEntityInterface
     public function setAllowPlainTextPkce(bool $allowPlainTextPkce): void
     {
         $this->allowPlainTextPkce = $allowPlainTextPkce;
+    }
+
+    /**
+     * @param list<non-empty-string> $grantTypes
+     */
+    public function setAllowedGrantTypes(array $grantTypes): void
+    {
+        $this->allowedGrantTypes = $grantTypes;
+    }
+
+    /**
+     * Returns true if the client supports the given grant type.
+     * If no grant types are configured, all grants are allowed (open by default).
+     */
+    public function supportsGrantType(string $grantType): bool
+    {
+        if (empty($this->allowedGrantTypes)) {
+            return true;
+        }
+
+        return \in_array($grantType, $this->allowedGrantTypes, true);
     }
 }

--- a/src/Repository/ClientRepository.php
+++ b/src/Repository/ClientRepository.php
@@ -64,6 +64,8 @@ final class ClientRepository implements ClientRepositoryInterface
         $clientEntity->setRedirectUri(array_map('strval', $client->getRedirectUris()));
         $clientEntity->setConfidential($client->isConfidential());
         $clientEntity->setAllowPlainTextPkce($client->isPlainTextPkceAllowed());
+        $grantTypes = array_map('strval', $client->getGrants());
+        $clientEntity->setAllowedGrantTypes($grantTypes);
 
         return $clientEntity;
     }

--- a/src/ValueObject/Grant.php
+++ b/src/ValueObject/Grant.php
@@ -19,6 +19,9 @@ class Grant implements \Stringable
         $this->grant = $grant;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function __toString(): string
     {
         return $this->grant;

--- a/tests/Acceptance/TokenEndpointTest.php
+++ b/tests/Acceptance/TokenEndpointTest.php
@@ -447,4 +447,30 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $this->assertSame('authorization_pending', $jsonResponse['error']);
         $this->assertSame('', $jsonResponse['hint']);
     }
+
+    public function testPasswordGrantDeniedForPublicClientWithRestrictedGrants(): void
+    {
+        $eventDispatcher = $this->client->getContainer()->get('event_dispatcher');
+
+        $eventDispatcher->addListener(OAuth2Events::USER_RESOLVE, static function (UserResolveEvent $event): void {
+            $event->setUser(FixtureFactory::createUser());
+        });
+
+        $this->client->request('POST', '/token', [
+            'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_RESTRICTED_GRANTS,
+            'grant_type' => 'password',
+            'username' => FixtureFactory::FIXTURE_USER,
+            'password' => FixtureFactory::FIXTURE_PASSWORD,
+        ]);
+
+        $response = $this->client->getResponse();
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+
+        $jsonResponse = json_decode($response->getContent(), true);
+
+        $this->assertSame('unauthorized_client', $jsonResponse['error']);
+        $this->assertSame('The authenticated client is not authorized to use this authorization grant type.', $jsonResponse['error_description']);
+    }
 }

--- a/tests/Fixtures/FixtureFactory.php
+++ b/tests/Fixtures/FixtureFactory.php
@@ -57,6 +57,7 @@ final class FixtureFactory
     public const FIXTURE_CLIENT_RESTRICTED_GRANTS = 'qux_restricted_grants';
     public const FIXTURE_CLIENT_RESTRICTED_SCOPES = 'quux_restricted_scopes';
     public const FIXTURE_PUBLIC_CLIENT = 'foo_public';
+    public const FIXTURE_PUBLIC_CLIENT_RESTRICTED_GRANTS = 'foo_public_restricted_grants';
     public const FIXTURE_PUBLIC_CLIENT_ALLOWED_TO_USE_PLAIN_CHALLENGE_METHOD = 'bar_public';
 
     public const FIXTURE_CLIENT_FIRST_REDIRECT_URI = 'https://example.org/oauth2/redirect-uri';
@@ -348,6 +349,10 @@ final class FixtureFactory
             ->setScopes(new Scope(self::FIXTURE_SCOPE_SECOND));
 
         $clients[] = (new Client('name', self::FIXTURE_PUBLIC_CLIENT, null))
+            ->setRedirectUris(new RedirectUri(self::FIXTURE_PUBLIC_CLIENT_REDIRECT_URI));
+
+        $clients[] = (new Client('name', self::FIXTURE_PUBLIC_CLIENT_RESTRICTED_GRANTS, null))
+            ->setGrants(new Grant('authorization_code'), new Grant('refresh_token'))
             ->setRedirectUris(new RedirectUri(self::FIXTURE_PUBLIC_CLIENT_REDIRECT_URI));
 
         $clients[] = (new Client('name', self::FIXTURE_PUBLIC_CLIENT_ALLOWED_TO_USE_PLAIN_CHALLENGE_METHOD, null))

--- a/tests/Integration/AuthorizationServerTest.php
+++ b/tests/Integration/AuthorizationServerTest.php
@@ -118,8 +118,8 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
         $response = $this->handleTokenRequest($request);
 
         // Response assertions.
-        $this->assertSame('invalid_client', $response['error']);
-        $this->assertSame('Client authentication failed', $response['error_description']);
+        $this->assertSame('unauthorized_client', $response['error']);
+        $this->assertSame('The authenticated client is not authorized to use this authorization grant type.', $response['error_description']);
     }
 
     public function testRestrictedScopeClient(): void


### PR DESCRIPTION
Implement supportsGrantType() on Entity\Client to restore per-client grant restrictions that were bypassed since League OAuth2 Server v9 stopped calling validateClient() for non-confidential clients.

Related: thephpleague/oauth2-server#1508
Fixes #278