### PR TITLE
Bump required dependencies for v2.0

### DIFF
--- a/.github/workflows/automated-refactoring.yml
+++ b/.github/workflows/automated-refactoring.yml
@@ -18,7 +18,7 @@ jobs:
             - name: "setup php"
               uses: "shivammathur/setup-php@v2"
               with:
-                php-version: "8.1"
+                php-version: "8.4"
                 tools: "composer, flex"
 
             - name: "enable Symfony Flex plugin"
@@ -27,7 +27,7 @@ jobs:
             - name: "install composer dependencies"
               uses: "ramsey/composer-install@v4"
               env:
-                SYMFONY_REQUIRE: "6.4.*"
+                SYMFONY_REQUIRE: "7.4.*"
                 COMPOSER_PREFER_STABLE: "1"
               with:
                 dependency-versions: "lowest"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,16 +14,16 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
-                symfony: ["6.4.*", "7.4.*", "8.0.*", "8.1.*"]
-                doctrine-orm: ["^2.14", "^3.0"]
+                php: ["8.4", "8.5"]
+                symfony: ["7.4.*", "8.0.*", "8.1.*"]
+                doctrine-orm: ["^3.0"]
                 dependency-versions: ["highest"]
                 composer-stable: ["1"]
                 can-fail: [false]
                 include:
-                    - php: "8.1"
-                      symfony: "6.4.*"
-                      doctrine-orm: "^2.14"
+                    - php: "8.4"
+                      symfony: "7.4.*"
+                      doctrine-orm: "^3.0"
                       dependency-versions: "lowest"
                       composer-stable: "1"
                       can-fail: false
@@ -32,27 +32,6 @@ jobs:
                       doctrine-orm: "^3.0"
                       composer-flags: ''
                       can-fail: true
-                exclude:
-                    - php: "8.1"
-                      symfony: "7.3.*"
-                    - php: "8.1"
-                      symfony: "7.4.*"
-                    - php: "8.1"
-                      symfony: "8.0.*"
-                    - php: "8.2"
-                      symfony: "8.0.*"
-                    - php: "8.3"
-                      symfony: "8.0.*"
-                    - doctrine-orm: "^2.14"
-                      symfony: "8.0.*"
-                    - php: "8.1"
-                      symfony: "8.1.*"
-                    - php: "8.2"
-                      symfony: "8.1.*"
-                    - php: "8.3"
-                      symfony: "8.1.*"
-                    - doctrine-orm: "^2.14"
-                      symfony: "8.1.*"
 
         name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }} - Doctrine ORM ${{ matrix.doctrine-orm }} - Composer ${{ matrix.dependency-versions }}"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/thephpl
 
 ## Development
 
-[PHP](https://www.php.net/) 8.1+ and [Composer](https://getcomposer.org/) 2+ are required for the development environment.
+[PHP](https://www.php.net/) 8.4+ and [Composer](https://getcomposer.org/) 2+ are required for the development environment.
 
 ### Building the environment
 

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,0 +1,7 @@
+UPGRADE GUIDE
+=============
+
+FROM 1.2 to 2.0
+---------------
+
+ * Bump the minimum required versions to PHP 8.4+, Symfony 7.4+, Doctrine ORM 3.0+ / DBAL 4.0+ with DoctrineBundle 2.15+, and `lcobucci/jwt` 5.0+

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -4,4 +4,4 @@ UPGRADE GUIDE
 FROM 1.2 to 2.0
 ---------------
 
- * Bump the minimum required versions to PHP 8.4+, Symfony 7.4+, Doctrine ORM 3.0+ / DBAL 4.0+ with DoctrineBundle 2.15+, and `lcobucci/jwt` 5.0+
+ * Bump the minimum required versions to PHP 8.4+, Symfony 7.4+, Doctrine ORM 3.0+ / DBAL 4.0+ with DoctrineBundle 2.15+, and `lcobucci/jwt` 5.6+

--- a/composer.json
+++ b/composer.json
@@ -16,35 +16,37 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.4",
         "ext-openssl": "*",
         "league/oauth2-server": "^9.2",
         "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",
         "symfony/deprecation-contracts": "^3.0",
-        "symfony/event-dispatcher": "^6.4|^7.4|^8.0",
-        "symfony/filesystem": "^6.4|^7.4|^8.0",
-        "symfony/framework-bundle": "^6.4|^7.4|^8.0",
-        "symfony/password-hasher": "^6.4|^7.4|^8.0",
-        "symfony/psr-http-message-bridge": "^6.4|^7.4|^8.0",
-        "symfony/security-bundle": "^6.4|^7.4|^8.0"
+        "symfony/event-dispatcher": "^7.4|^8.0",
+        "symfony/filesystem": "^7.4|^8.0",
+        "symfony/framework-bundle": "^7.4|^8.0",
+        "symfony/password-hasher": "^7.4|^8.0",
+        "symfony/psr-http-message-bridge": "^7.4|^8.0",
+        "symfony/security-bundle": "^7.4|^8.0"
     },
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
-        "doctrine/doctrine-bundle": "^2.8|^3.0",
-        "doctrine/orm": "^2.14|^3.0",
+        "doctrine/dbal": "^4.0",
+        "doctrine/doctrine-bundle": "^2.15|^3.0",
+        "doctrine/orm": "^3.0",
         "php-cs-fixer/shim": "^3.38",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-symfony": "^2.0",
         "rector/rector": "dev-main",
-        "symfony/browser-kit": "^6.4|^7.4|^8.0",
+        "symfony/browser-kit": "^7.4|^8.0",
         "symfony/phpunit-bridge": "^8.1"
     },
     "conflict": {
-        "doctrine/doctrine-bundle": "<2.8.0",
-        "doctrine/orm": "<2.14",
-        "symfony/console": "<6.1"
+        "doctrine/dbal": "<4.0",
+        "doctrine/doctrine-bundle": "<2.15",
+        "doctrine/orm": "<3.0",
+        "lcobucci/jwt": "<5.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "Allow usage of doctrine as persistence layer",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.4",
         "ext-openssl": "*",
+        "lcobucci/jwt": "^5.6",
         "league/oauth2-server": "^9.2",
         "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",
@@ -45,8 +46,7 @@
     "conflict": {
         "doctrine/dbal": "<4.0",
         "doctrine/doctrine-bundle": "<2.15",
-        "doctrine/orm": "<3.0",
-        "lcobucci/jwt": "<5.0"
+        "doctrine/orm": "<3.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "Allow usage of doctrine as persistence layer",

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ For implementation into Symfony projects, please see [bundle documentation](basi
 
 ## Requirements
 
-* [PHP 8.1](http://php.net/releases/8_1_0.php) or greater
-* [Symfony 6.4](https://symfony.com/roadmap/6.4) or greater
+* [PHP 8.4](http://php.net/releases/8_4_0.php) or greater
+* [Symfony 7.4](https://symfony.com/roadmap/7.4) or greater
 
 ## Installation
 

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,14 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
+use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Php84\Rector\Foreach_\ForeachToArrayAnyRector;
+use Rector\Php84\Rector\MethodCall\NewMethodCallWithoutParenthesesRector;
+use Rector\Symfony\Symfony80\Rector\Class_\RemoveEraseCredentialsRector;
+use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -15,4 +23,22 @@ return RectorConfig::configure()
     // ->withCodeQualityLevel(0)
     ->withPreparedSets(typeDeclarations: true, deadCode: true)
     ->withComposerBased(symfony: true, phpunit: true, doctrine: true)
+    // Rules newly triggered by the 2.0 PHP 8.4 / Symfony 7.4 floor bump are skipped for now:
+    //  - ReadOnlyClassRector would introduce BC breaks (readonly classes on value objects/models).
+    //  - RemoveEraseCredentialsRector / RemoveEmptyClassMethodRector would drop public methods that
+    //    must stay while Symfony 7.4 is supported (e.g. ClientCredentialsUser::eraseCredentials()).
+    //    RemoveEraseCredentialsRector only registers on Symfony >= 8.0, so the refactoring CI (which
+    //    runs on the 7.4 floor) reports it as "never registered" — that note is harmless (exit 0).
+    // The remaining (BC-safe) modernizations are deferred to a follow-up after PR #291 lands,
+    // together with the invokable-command refactor, to avoid churn/conflicts in files #291 rewrites.
+    ->withSkip([
+        ReadOnlyClassRector::class,
+        RemoveEraseCredentialsRector::class,
+        RemoveEmptyClassMethodRector::class,
+        AddOverrideAttributeToOverriddenMethodsRector::class,
+        AddArrowFunctionReturnTypeRector::class,
+        AddTypeToConstRector::class,
+        ForeachToArrayAnyRector::class,
+        NewMethodCallWithoutParenthesesRector::class,
+    ])
 ;

--- a/src/Entity/AccessToken.php
+++ b/src/Entity/AccessToken.php
@@ -45,14 +45,8 @@ final class AccessToken implements AccessTokenEntityInterface
 
         $builderWithExtraClaims = $this->withJwtBuilder($this->jwtConfiguration->builder());
 
-        $builderFactory = (static fn (ClaimsFormatter $claimFormatter): Builder => $builderWithExtraClaims);
-
-        if (!method_exists($this->jwtConfiguration, 'withBuilderFactory')) { // @phpstan-ignore function.alreadyNarrowedType
-            $this->jwtConfiguration->setBuilderFactory($builderFactory);
-
-            return;
-        }
-
-        $this->jwtConfiguration = $this->jwtConfiguration->withBuilderFactory($builderFactory);
+        $this->jwtConfiguration = $this->jwtConfiguration->withBuilderFactory(
+            static fn (ClaimsFormatter $claimFormatter): Builder => $builderWithExtraClaims
+        );
     }
 }

--- a/tests/Unit/CheckScopeListenerTest.php
+++ b/tests/Unit/CheckScopeListenerTest.php
@@ -25,8 +25,7 @@ final class CheckScopeListenerTest extends TestCase
             $this->createMock(Passport::class)
         );
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         (new CheckScopeListener($requestStack))->checkPassport($event);
 
@@ -44,8 +43,7 @@ final class CheckScopeListenerTest extends TestCase
             $passport
         );
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [], ['oauth2_scopes' => ['scope_one']]));
+        $requestStack = new RequestStack([new Request([], [], ['oauth2_scopes' => ['scope_one']])]);
 
         (new CheckScopeListener($requestStack))->checkPassport($event);
 
@@ -63,8 +61,7 @@ final class CheckScopeListenerTest extends TestCase
             $passport
         );
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [], ['oauth2_scopes' => ['scope_two']]));
+        $requestStack = new RequestStack([new Request([], [], ['oauth2_scopes' => ['scope_two']])]);
 
         $this->expectException(InsufficientScopesException::class);
 


### PR DESCRIPTION
Removes support for:

- PHP < 8.4
- Symfony < 7.4
- Doctrine DBAL < 4
- Doctrine ORM < 3
- Lcobuxci JWT < 5