### PR TITLE
Do not require a database migration when upgrading to `^1.2`

### DIFF
--- a/config/storage/doctrine.php
+++ b/config/storage/doctrine.php
@@ -28,6 +28,7 @@ return static function (ContainerConfigurator $container): void {
                 null,
                 null,
                 null,
+                null,
             ])
         ->alias(Driver::class, 'league.oauth2_server.persistence.driver')
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ For implementation into Symfony projects, please see [bundle documentation](basi
             revoke_refresh_tokens: true
 
             # Whether to enable the device code grant
-            enable_device_code_grant: true
+            enable_device_code_grant: false
 
             # The full URI the user will need to visit to enter the user code
             device_code_verification_uri: ''

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -143,7 +143,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('enable_device_code_grant')
                     ->info('Whether to enable the device code grant')
-                    ->defaultTrue()
+                    ->defaultFalse()
                 ->end()
                 ->scalarNode('device_code_verification_uri')
                     ->info('The full URI the user will need to visit to enter the user code')

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -383,6 +383,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
             ->replaceArgument(0, $config['client']['classname'])
             ->replaceArgument(1, $config['authorization_server']['persist_access_token'])
             ->replaceArgument(2, $persistenceConfig['table_prefix'])
+            ->replaceArgument(3, $config['authorization_server']['enable_device_code_grant'])
         ;
 
         $container->setParameter('league.oauth2_server.persistence.doctrine.enabled', true);

--- a/src/Persistence/Mapping/Driver.php
+++ b/src/Persistence/Mapping/Driver.php
@@ -26,6 +26,7 @@ class Driver implements MappingDriver
         private readonly string $clientClass,
         private readonly bool $persistAccessToken,
         private readonly string $tablePrefix = 'oauth2_',
+        private readonly bool $enableDeviceCode = false,
     ) {
     }
 
@@ -70,10 +71,10 @@ class Driver implements MappingDriver
         return array_merge(
             [
                 AbstractClient::class,
-                DeviceCode::class,
                 AuthorizationCode::class,
                 RefreshToken::class,
             ],
+            $this->enableDeviceCode ? [DeviceCode::class] : [],
             Client::class === $this->clientClass ? [Client::class] : [],
             $this->persistAccessToken ? [AccessToken::class] : []
         );

--- a/src/Persistence/Mapping/Driver.php
+++ b/src/Persistence/Mapping/Driver.php
@@ -92,7 +92,7 @@ class Driver implements MappingDriver
         (new ClassMetadataBuilder($metadata))
             ->setMappedSuperClass()
             ->createField('name', 'string')->length(128)->build()
-            ->createField('secret', 'string')->length(255)->nullable(true)->build()
+            ->createField('secret', 'string')->length(128)->nullable(true)->build()
             ->createField('redirectUris', 'oauth2_redirect_uri')->nullable(true)->build()
             ->createField('grants', 'oauth2_grant')->nullable(true)->build()
             ->createField('scopes', 'oauth2_scope')->nullable(true)->build()

--- a/tests/Fixtures/config/packages/league_oauth2_server.php
+++ b/tests/Fixtures/config/packages/league_oauth2_server.php
@@ -14,6 +14,7 @@ return static function (ContainerConfigurator $container): void {
             'encryption_key' => TestHelper::ENCRYPTION_KEY,
             'enable_password_grant' => true,
             'enable_implicit_grant' => true,
+            'enable_device_code_grant' => true,
             'access_token_ttl' => 'PT2H',
         ],
         'resource_server' => ['public_key' => TestHelper::PUBLIC_KEY_PATH],


### PR DESCRIPTION
Fix #293 