### PR TITLE
Fix BC break: revert secret field length

### DIFF
--- a/src/Persistence/Mapping/Driver.php
+++ b/src/Persistence/Mapping/Driver.php
@@ -92,7 +92,7 @@ class Driver implements MappingDriver
         (new ClassMetadataBuilder($metadata))
             ->setMappedSuperClass()
             ->createField('name', 'string')->length(128)->build()
-            ->createField('secret', 'string')->length(255)->nullable(true)->build()
+            ->createField('secret', 'string')->length(128)->nullable(true)->build()
             ->createField('redirectUris', 'oauth2_redirect_uri')->nullable(true)->build()
             ->createField('grants', 'oauth2_grant')->nullable(true)->build()
             ->createField('scopes', 'oauth2_scope')->nullable(true)->build()


### PR DESCRIPTION
This change, introduced in d0ad780ac85b76c39c51888a61ba6e3923bb3e8c, can be safely reverted to avoid requiring a Doctrine migration.

A length limit of 128 characters is sufficient for current hashing algorithms.