### PR TITLE
Skip deprecated service references when unnecessary

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -171,8 +171,6 @@ return static function (ContainerConfigurator $container): void {
                 null,
             ])
             ->call('setEmitter', [service('league.oauth2_server.emitter')])
-            // TODO remove next line when bundle interface and configurator will be deleted
-            ->configurator(service(GrantConfigurator::class))
         ->alias(AuthorizationServer::class, 'league.oauth2_server.authorization_server')
 
         // League bearer token validator

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
 >
     <php>
         <server name="KERNEL_CLASS" value="League\Bundle\OAuth2ServerBundle\Tests\Fixtures\TestKernel" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;ignoreFile=./tests/baseline-ignore" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     </php>
 
     <testsuites>

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -237,7 +237,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
             ]);
         }
 
-        // TODO remove code block when grant configurator is deleted
+        // @deprecated remove code block when grant configurator is deleted
         if ([] !== $tags = $container->findTaggedServiceIds('league.oauth2_server.authorization_server.grant')) {
             $registerConfigurator = false;
             foreach (array_keys($tags) as $serviceId) {

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace League\Bundle\OAuth2ServerBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use League\Bundle\OAuth2ServerBundle\AuthorizationServer\GrantConfigurator;
 use League\Bundle\OAuth2ServerBundle\AuthorizationServer\GrantTypeInterface;
 use League\Bundle\OAuth2ServerBundle\Command\ClearExpiredTokensCommand;
 use League\Bundle\OAuth2ServerBundle\Command\CreateClientCommand;
@@ -234,6 +235,23 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
                 new Reference(ImplicitGrant::class),
                 new Definition(\DateInterval::class, [$config['access_token_ttl']]),
             ]);
+        }
+
+        // TODO remove code block when grant configurator is deleted
+        if ([] !== $tags = $container->findTaggedServiceIds('league.oauth2_server.authorization_server.grant')) {
+            $registerConfigurator = false;
+            foreach (array_keys($tags) as $serviceId) {
+                $grantDefinition = $container->findDefinition($serviceId);
+                $grantClass = $grantDefinition->getClass() ?? (string) $serviceId;
+                $refGrantClass = $container->getReflectionClass($grantClass, false);
+                if ($refGrantClass instanceof \ReflectionClass && $refGrantClass->implementsInterface(GrantTypeInterface::class)) {
+                    $registerConfigurator = true;
+                    break;
+                }
+            }
+            if ($registerConfigurator) {
+                $authorizationServer->setConfigurator(new Reference(GrantConfigurator::class));
+            }
         }
 
         $this->configureGrants($container, $config);

--- a/tests/Unit/ExtensionTest.php
+++ b/tests/Unit/ExtensionTest.php
@@ -7,6 +7,7 @@ namespace League\Bundle\OAuth2ServerBundle\Tests\Unit;
 use League\Bundle\OAuth2ServerBundle\AuthorizationServer\GrantConfigurator;
 use League\Bundle\OAuth2ServerBundle\DependencyInjection\LeagueOAuth2ServerExtension;
 use League\Bundle\OAuth2ServerBundle\Manager\InMemory\ScopeManager;
+use League\Bundle\OAuth2ServerBundle\Tests\Fixtures\Grant\FakeLegacyGrant;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -189,10 +190,7 @@ final class ExtensionTest extends TestCase
 
         // TODO remove code bloc when grant configurator is deleted
         $configurator = $authorizationServer->getConfigurator();
-        $this->assertIsArray($configurator);
-        $this->assertInstanceOf(Reference::class, $configurator[0]);
-        $this->assertSame(GrantConfigurator::class, (string) $configurator[0]);
-        $this->assertSame('__invoke', $configurator[1]);
+        $this->assertNull($configurator);
     }
 
     public function scopeProvider(): iterable
@@ -208,6 +206,25 @@ final class ExtensionTest extends TestCase
             ['unknown_scope'],
             false,
         ];
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGrantConfiguratorIsEnabledWhenLegacyGrantIsTagged(): void
+    {
+        $container = new ContainerBuilder();
+        $extension = new LeagueOAuth2ServerExtension();
+        $container->register(FakeLegacyGrant::class)->addTag('league.oauth2_server.authorization_server.grant');
+
+        $extension->load($this->getValidConfiguration(), $container);
+
+        $authorizationServer = $container->findDefinition(AuthorizationServer::class);
+        $configurator = $authorizationServer->getConfigurator();
+        $this->assertIsArray($configurator);
+        $this->assertInstanceOf(Reference::class, $configurator[0]);
+        $this->assertSame(GrantConfigurator::class, (string) $configurator[0]);
+        $this->assertSame('__invoke', $configurator[1]);
     }
 
     /**

--- a/tests/baseline-ignore
+++ b/tests/baseline-ignore
@@ -1,5 +1,0 @@
-# This file contains patterns to be ignored while testing for use of
-# deprecated code
-
-
-%Since league/oauth2-server-bundle 1.2: The \"league.oauth2_server.authorization_server.grant_configurator\" service is deprecated. It will be removed in 2.0%


### PR DESCRIPTION
Avoid referencing the deprecated `GrantConfigurator` if there is no legacy grant