### PR TITLE
Remove support for Symfony 8.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
-                symfony: ["6.4.*", "7.4.*", "8.0.*", "8.1.*"]
+                symfony: ["6.4.*", "7.4.*", "8.1.*"]
                 doctrine-orm: ["^2.14", "^3.0"]
                 dependency-versions: ["highest"]
                 composer-stable: ["1"]
@@ -34,17 +34,7 @@ jobs:
                       can-fail: true
                 exclude:
                     - php: "8.1"
-                      symfony: "7.3.*"
-                    - php: "8.1"
                       symfony: "7.4.*"
-                    - php: "8.1"
-                      symfony: "8.0.*"
-                    - php: "8.2"
-                      symfony: "8.0.*"
-                    - php: "8.3"
-                      symfony: "8.0.*"
-                    - doctrine-orm: "^2.14"
-                      symfony: "8.0.*"
                     - php: "8.1"
                       symfony: "8.1.*"
                     - php: "8.2"

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         "nyholm/psr7": "^1.4",
         "psr/http-factory": "^1.0",
         "symfony/deprecation-contracts": "^3.0",
-        "symfony/event-dispatcher": "^6.4|^7.4|^8.0",
-        "symfony/filesystem": "^6.4|^7.4|^8.0",
-        "symfony/framework-bundle": "^6.4|^7.4|^8.0",
-        "symfony/password-hasher": "^6.4|^7.4|^8.0",
-        "symfony/psr-http-message-bridge": "^6.4|^7.4|^8.0",
-        "symfony/security-bundle": "^6.4|^7.4|^8.0"
+        "symfony/event-dispatcher": "^6.4|^7.4|^8.1",
+        "symfony/filesystem": "^6.4|^7.4|^8.1",
+        "symfony/framework-bundle": "^6.4|^7.4|^8.1",
+        "symfony/password-hasher": "^6.4|^7.4|^8.1",
+        "symfony/psr-http-message-bridge": "^6.4|^7.4|^8.1",
+        "symfony/security-bundle": "^6.4|^7.4|^8.1"
     },
     "require-dev": {
         "ext-pdo": "*",
@@ -38,7 +38,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-symfony": "^2.0",
         "rector/rector": "^2.5",
-        "symfony/browser-kit": "^6.4|^7.4|^8.0",
+        "symfony/browser-kit": "^6.4|^7.4|^8.1",
         "symfony/phpunit-bridge": "^8.1"
     },
     "conflict": {


### PR DESCRIPTION
Symfony 8.0 is EOL and the `doctrine/orm:^3 symfony/doctrine-bridge:8.0.*` combination can no longer be tested due to https://github.com/symfony/symfony/pull/65169