### PR TITLE
Add configuration for expired token cleanup

### DIFF
--- a/config/storage/doctrine.php
+++ b/config/storage/doctrine.php
@@ -45,12 +45,14 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 null,
                 null,
+                null,
             ])
         ->alias(AccessTokenManagerInterface::class, 'league.oauth2_server.manager.doctrine.access_token')
         ->alias(AccessTokenManager::class, 'league.oauth2_server.manager.doctrine.access_token')
 
         ->set('league.oauth2_server.manager.doctrine.refresh_token', RefreshTokenManager::class)
             ->args([
+                null,
                 null,
             ])
         ->alias(RefreshTokenManagerInterface::class, 'league.oauth2_server.manager.doctrine.refresh_token')
@@ -59,12 +61,14 @@ return static function (ContainerConfigurator $container): void {
         ->set('league.oauth2_server.manager.doctrine.device_code', DeviceCodeManager::class)
             ->args([
                 null,
+                null,
             ])
         ->alias(DeviceCodeManagerInterface::class, 'league.oauth2_server.manager.doctrine.device_code')
         ->alias(DeviceCodeManager::class, 'league.oauth2_server.manager.doctrine.device_code')
 
         ->set('league.oauth2_server.manager.doctrine.authorization_code', AuthorizationCodeManager::class)
             ->args([
+                null,
                 null,
             ])
         ->alias(AuthorizationCodeManagerInterface::class, 'league.oauth2_server.manager.doctrine.authorization_code')

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,10 @@ For implementation into Symfony projects, please see [bundle documentation](basi
 
                 # Table name prefix.
                 table_prefix:         oauth2_
+
+                # The delay in seconds in which expired access/refresh/authorization-code/device-code will be removed (default 0)
+                expired_token_cleanup_delay: PT0S
+
             in_memory:            ~
 
         # Set a custom prefix that replaces the default 'ROLE_OAUTH2_' role prefix

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -254,6 +254,10 @@ final class Configuration implements ConfigurationInterface
                             ->cannotBeEmpty()
                             ->defaultValue('oauth2_')
                         ->end()
+                        ->scalarNode('expired_token_cleanup_delay')
+                            ->info('The delay in seconds in which expired access/refresh/authorization-code/device-code will be removed. Default PT0S.')
+                            ->defaultValue('PT0S')
+                        ->end()
                     ->end()
                 ->end()
                 // In-memory persistence

--- a/src/DependencyInjection/LeagueOAuth2ServerExtension.php
+++ b/src/DependencyInjection/LeagueOAuth2ServerExtension.php
@@ -365,6 +365,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
     private function configureDoctrinePersistence(ContainerBuilder $container, array $config, array $persistenceConfig): void
     {
         $entityManagerName = $persistenceConfig['entity_manager'];
+        $expiredTokenCleanupDelay = $persistenceConfig['expired_token_cleanup_delay'];
 
         $entityManager = new Reference(
             \sprintf('doctrine.orm.%s_entity_manager', $entityManagerName)
@@ -374,6 +375,7 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
             ->findDefinition(AccessTokenManager::class)
             ->replaceArgument(0, $entityManager)
             ->replaceArgument(1, $config['authorization_server']['persist_access_token'])
+            ->replaceArgument(2, $expiredTokenCleanupDelay)
         ;
 
         $container
@@ -385,16 +387,19 @@ final class LeagueOAuth2ServerExtension extends Extension implements PrependExte
         $container
             ->findDefinition(RefreshTokenManager::class)
             ->replaceArgument(0, $entityManager)
+            ->replaceArgument(1, $expiredTokenCleanupDelay)
         ;
 
         $container
             ->findDefinition(AuthorizationCodeManager::class)
             ->replaceArgument(0, $entityManager)
+            ->replaceArgument(1, $expiredTokenCleanupDelay)
         ;
 
         $container
             ->findDefinition(DeviceCodeManager::class)
             ->replaceArgument(0, $entityManager)
+            ->replaceArgument(1, $expiredTokenCleanupDelay)
         ;
 
         $container

--- a/src/Manager/Doctrine/AccessTokenManager.php
+++ b/src/Manager/Doctrine/AccessTokenManager.php
@@ -15,6 +15,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly bool $persistAccessToken,
+        private readonly string $expireCleanupDelay,
     ) {
     }
 
@@ -43,12 +44,14 @@ final class AccessTokenManager implements AccessTokenManagerInterface
             return 0;
         }
 
+        $expiry = (new \DateTimeImmutable())->sub(new \DateInterval($this->expireCleanupDelay));
+
         /** @var array{identifier: string}[] */
         $results = $this->entityManager->createQueryBuilder()
             ->select('at.identifier')
             ->from(AccessToken::class, 'at')
             ->where('at.expiry < :expiry')
-            ->setParameter('expiry', new \DateTimeImmutable(), 'datetime_immutable')
+            ->setParameter('expiry', $expiry, 'datetime_immutable')
             ->getQuery()
             ->getScalarResult();
         if (0 === \count($results)) {

--- a/src/Manager/Doctrine/AuthorizationCodeManager.php
+++ b/src/Manager/Doctrine/AuthorizationCodeManager.php
@@ -13,6 +13,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
+        private readonly string $expireCleanupDelay,
     ) {
     }
 
@@ -29,11 +30,13 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
 
     public function clearExpired(): int
     {
+        $expiry = (new \DateTimeImmutable())->sub(new \DateInterval($this->expireCleanupDelay));
+
         /** @var int */
         return $this->entityManager->createQueryBuilder()
             ->delete(AuthorizationCode::class, 'ac')
             ->where('ac.expiry < :expiry')
-            ->setParameter('expiry', new \DateTimeImmutable(), 'datetime_immutable')
+            ->setParameter('expiry', $expiry, 'datetime_immutable')
             ->getQuery()
             ->execute();
     }

--- a/src/Manager/Doctrine/DeviceCodeManager.php
+++ b/src/Manager/Doctrine/DeviceCodeManager.php
@@ -13,6 +13,7 @@ final class DeviceCodeManager implements DeviceCodeManagerInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
+        private readonly string $expireCleanupDelay,
     ) {
     }
 
@@ -41,11 +42,13 @@ final class DeviceCodeManager implements DeviceCodeManagerInterface
 
     public function clearExpired(): int
     {
+        $expiry = (new \DateTimeImmutable())->sub(new \DateInterval($this->expireCleanupDelay));
+
         /** @var int */
         return $this->entityManager->createQueryBuilder()
             ->delete(DeviceCode::class, 'at')
             ->where('at.expiry < :expiry')
-            ->setParameter('expiry', new \DateTimeImmutable(), 'datetime_immutable')
+            ->setParameter('expiry', $expiry, 'datetime_immutable')
             ->getQuery()
             ->execute();
     }

--- a/src/Manager/Doctrine/RefreshTokenManager.php
+++ b/src/Manager/Doctrine/RefreshTokenManager.php
@@ -13,6 +13,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
+        private readonly string $expireCleanupDelay,
     ) {
     }
 
@@ -29,11 +30,13 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
 
     public function clearExpired(): int
     {
+        $expiry = (new \DateTimeImmutable())->sub(new \DateInterval($this->expireCleanupDelay));
+
         /** @var int */
         return $this->entityManager->createQueryBuilder()
             ->delete(RefreshToken::class, 'rt')
             ->where('rt.expiry < :expiry')
-            ->setParameter('expiry', new \DateTimeImmutable(), 'datetime_immutable')
+            ->setParameter('expiry', $expiry, 'datetime_immutable')
             ->getQuery()
             ->execute();
     }

--- a/tests/Acceptance/DoctrineAccessTokenManagerTest.php
+++ b/tests/Acceptance/DoctrineAccessTokenManagerTest.php
@@ -22,7 +22,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
 
-        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, true);
+        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, true, 'PT0S');
 
         $client = new Client('client', 'client', 'secret');
         $em->persist($client);
@@ -43,12 +43,37 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         );
     }
 
+    public function testClearExpiredWithCleanupDelay(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+
+        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, true, 'PT1H');
+
+        $client = new Client('client', 'client', 'secret');
+        $em->persist($client);
+        $em->flush();
+
+        $recentlyExpiredAccessToken = $this->buildAccessToken('1111', '-30 minutes', $client);
+        $expiredAccessToken = $this->buildAccessToken('2222', '-2 hours', $client);
+
+        $doctrineAccessTokenManager->save($recentlyExpiredAccessToken);
+        $doctrineAccessTokenManager->save($expiredAccessToken);
+
+        $this->assertSame(1, $doctrineAccessTokenManager->clearExpired());
+
+        $this->assertSame(
+            [$recentlyExpiredAccessToken],
+            $em->getRepository(AccessToken::class)->findBy([], ['identifier' => 'ASC'])
+        );
+    }
+
     public function testClearExpiredWithoutSavingAccessToken(): void
     {
         /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
 
-        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, false);
+        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, false, 'PT0S');
 
         $client = new Client('name', 'client', 'secret');
         $em->persist($client);
@@ -105,7 +130,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
     {
         /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
-        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, true);
+        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, true, 'PT0S');
 
         $client = new Client('client', 'client', 'secret');
         $em->persist($client);
@@ -132,7 +157,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
     {
         /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
-        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, false);
+        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em, false, 'PT0S');
 
         $client = new Client('name', 'client', 'secret');
         $em->persist($client);

--- a/tests/Acceptance/DoctrineAuthCodeManagerTest.php
+++ b/tests/Acceptance/DoctrineAuthCodeManagerTest.php
@@ -21,7 +21,7 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
         /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
 
-        $doctrineAuthCodeManager = new DoctrineAuthCodeManager($em);
+        $doctrineAuthCodeManager = new DoctrineAuthCodeManager($em, 'PT0S');
 
         $client = new Client('client', 'client', 'secret');
         $em->persist($client);
@@ -39,6 +39,32 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
 
         $this->assertSame(
             $testData['output'],
+            $em->getRepository(AuthorizationCode::class)->findBy([], ['identifier' => 'ASC'])
+        );
+    }
+
+    public function testClearExpiredWithCleanupDelay(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+
+        $doctrineAuthCodeManager = new DoctrineAuthCodeManager($em, 'PT1H');
+
+        $client = new Client('client', 'client', 'secret');
+        $em->persist($client);
+
+        $recentlyExpiredAuthCode = $this->buildAuthCode('1111', '-30 minutes', $client);
+        $expiredAuthCode = $this->buildAuthCode('2222', '-2 hours', $client);
+
+        $doctrineAuthCodeManager->save($recentlyExpiredAuthCode);
+        $doctrineAuthCodeManager->save($expiredAuthCode);
+
+        $em->flush();
+
+        $this->assertSame(1, $doctrineAuthCodeManager->clearExpired());
+
+        $this->assertSame(
+            [$recentlyExpiredAuthCode],
             $em->getRepository(AuthorizationCode::class)->findBy([], ['identifier' => 'ASC'])
         );
     }

--- a/tests/Acceptance/DoctrineDeviceCodeManagerTest.php
+++ b/tests/Acceptance/DoctrineDeviceCodeManagerTest.php
@@ -21,7 +21,7 @@ final class DoctrineDeviceCodeManagerTest extends AbstractAcceptanceTest
         /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
 
-        $doctrineDeviceCodeManager = new DoctrineDeviceCodeManager($em);
+        $doctrineDeviceCodeManager = new DoctrineDeviceCodeManager($em, 'PT0S');
 
         $client = new Client('client', 'client', 'secret');
         $em->persist($client);
@@ -39,6 +39,32 @@ final class DoctrineDeviceCodeManagerTest extends AbstractAcceptanceTest
 
         $this->assertSame(
             array_values($testData['output']),
+            $em->getRepository(DeviceCode::class)->findBy([], ['identifier' => 'ASC'])
+        );
+    }
+
+    public function testClearExpiredWithCleanupDelay(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+
+        $doctrineDeviceCodeManager = new DoctrineDeviceCodeManager($em, 'PT1H');
+
+        $client = new Client('client', 'client', 'secret');
+        $em->persist($client);
+
+        $recentlyExpiredDeviceCode = $this->buildDeviceCode('1111', '-30 minutes', $client);
+        $expiredDeviceCode = $this->buildDeviceCode('2222', '-2 hours', $client);
+
+        $doctrineDeviceCodeManager->save($recentlyExpiredDeviceCode);
+        $doctrineDeviceCodeManager->save($expiredDeviceCode);
+
+        $em->flush();
+
+        $this->assertSame(1, $doctrineDeviceCodeManager->clearExpired());
+
+        $this->assertSame(
+            [$recentlyExpiredDeviceCode],
             $em->getRepository(DeviceCode::class)->findBy([], ['identifier' => 'ASC'])
         );
     }

--- a/tests/Acceptance/DoctrineRefreshTokenManagerTest.php
+++ b/tests/Acceptance/DoctrineRefreshTokenManagerTest.php
@@ -22,7 +22,7 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
         /** @var EntityManagerInterface $em */
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
 
-        $doctrineRefreshTokenManager = new DoctrineRefreshTokenManager($em);
+        $doctrineRefreshTokenManager = new DoctrineRefreshTokenManager($em, 'PT0S');
 
         $client = new Client('client', 'client', 'secret');
         $em->persist($client);
@@ -42,6 +42,35 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
 
         $this->assertSame(
             $testData['output'],
+            $em->getRepository(RefreshToken::class)->findBy([], ['identifier' => 'ASC'])
+        );
+    }
+
+    public function testClearExpiredWithCleanupDelay(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+
+        $doctrineRefreshTokenManager = new DoctrineRefreshTokenManager($em, 'PT1H');
+
+        $client = new Client('client', 'client', 'secret');
+        $em->persist($client);
+        $em->flush();
+
+        $recentlyExpiredRefreshToken = $this->buildRefreshToken('1111', '-30 minutes', $client);
+        $expiredRefreshToken = $this->buildRefreshToken('2222', '-2 hours', $client);
+
+        $em->persist($recentlyExpiredRefreshToken->getAccessToken());
+        $doctrineRefreshTokenManager->save($recentlyExpiredRefreshToken);
+        $em->persist($expiredRefreshToken->getAccessToken());
+        $doctrineRefreshTokenManager->save($expiredRefreshToken);
+
+        $em->flush();
+
+        $this->assertSame(1, $doctrineRefreshTokenManager->clearExpired());
+
+        $this->assertSame(
+            [$recentlyExpiredRefreshToken],
             $em->getRepository(RefreshToken::class)->findBy([], ['identifier' => 'ASC'])
         );
     }


### PR DESCRIPTION
Issue: #305
Breaking change: no

Adds configuration option:
```yaml
league_oauth2_server:
   authorization_server: 
       persistence:
            doctrine:
                ...

                # The delay in seconds in which expired access/refresh/authorization-code/device-code will be removed (default 0)
                expired_token_cleanup_delay: PT0S
```

By default the token cleanup cron will immediately delete all tokens with expiry < now(). Setting the option to for example `PT1H`, will only remove tokens that have an expiry of atleast 1 hour old. This prevents small time difference between instances.
